### PR TITLE
DocumentFragment methods.

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -20,10 +20,10 @@ public function __construct($document = null) {
 	$this->registerNodeClass("\DOMCharacterData", "\Gt\Dom\CharacterData");
 	$this->registerNodeClass("\DOMText", "\Gt\Dom\Text");
 	$this->registerNodeClass("\DOMComment", "\Gt\Dom\Comment");
-    if ($document instanceof \DOMDocument) {
-        $this->appendChild($this->importNode($document->documentElement, true));
-        return;
-    }
+	if ($document instanceof \DOMDocument) {
+		$this->appendChild($this->importNode($document->documentElement, true));
+		return;
+	}
 }
 
 };

--- a/src/DocumentFragment.php
+++ b/src/DocumentFragment.php
@@ -35,8 +35,8 @@ public function getElementById(string $id)/*:?Element*/ {
  * @return Element|null
  */
 public function querySelector(string $selectors) {
-    return $this->callMethodOnTemporaryElement(
-        "querySelector", [$selectors]);
+	return $this->callMethodOnTemporaryElement(
+		"querySelector", [$selectors]);
 }
 
 /**
@@ -44,27 +44,27 @@ public function querySelector(string $selectors) {
  * @return HTMLCollection
  */
 public function querySelectorAll(string $selectors):HTMLCollection {
-    return $this->callMethodOnTemporaryElement(
-        "querySelectorAll", [$selectors]);
+	return $this->callMethodOnTemporaryElement(
+		"querySelectorAll", [$selectors]);
 }
 
 private function callMethodOnTemporaryElement(string $methodName, array $args) {
 	$childNodes = [];
 
-    $tempElement = $this->ownerDocument->createElement("document-fragment");
+	$tempElement = $this->ownerDocument->createElement("document-fragment");
 
 	while($this->firstChild) {
 		$childNodes []= $this->firstChild;
 		$tempElement->appendChild($this->firstChild);
 	}
 
-    $result = call_user_func_array([$tempElement, $methodName], $args);
+	$result = call_user_func_array([$tempElement, $methodName], $args);
 
 	foreach($childNodes as $node) {
 		$this->appendChild($node);
 	}
 
-    return $result;
+	return $result;
 }
 
 }#

--- a/src/DocumentFragment.php
+++ b/src/DocumentFragment.php
@@ -21,4 +21,41 @@ namespace Gt\Dom;
 class DocumentFragment extends \DOMDocumentFragment {
 use LiveProperty, ParentNode;
 
+/**
+ * @param string $selectors CSS selector(s)
+ * @return Element|null
+ */
+public function querySelector(string $selectors) {
+    return $this->callMethodOnTemporaryElement(
+        "querySelector", [$selectors]);
+}
+
+/**
+ * @param string $selectors CSS selector(s)
+ * @return HTMLCollection
+ */
+public function querySelectorAll(string $selectors):HTMLCollection {
+    return $this->callMethodOnTemporaryElement(
+        "querySelectorAll", [$selectors]);
+}
+
+private function callMethodOnTemporaryElement(string $methodName, array $args) {
+	$childNodes = [];
+
+    $tempElement = $this->ownerDocument->createElement("document-fragment");
+
+	while($this->firstChild) {
+		$childNodes []= $this->firstChild;
+		$tempElement->appendChild($this->firstChild);
+	}
+
+    $result = call_user_func_array([$tempElement, $methodName], $args);
+
+	foreach($childNodes as $node) {
+		$this->appendChild($node);
+	}
+
+    return $result;
+}
+
 }#

--- a/src/DocumentFragment.php
+++ b/src/DocumentFragment.php
@@ -22,6 +22,15 @@ class DocumentFragment extends \DOMDocumentFragment {
 use LiveProperty, ParentNode;
 
 /**
+ * @param string $id
+ * @return Element|null
+ */
+public function getElementById(string $id)/*:?Element*/ {
+	return $this->callMethodOnTemporaryElement(
+		"querySelector", ["#" . $id]);
+}
+
+/**
  * @param string $selectors CSS selector(s)
  * @return Element|null
  */

--- a/src/Element.php
+++ b/src/Element.php
@@ -6,6 +6,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 
 /**
  * Represents an object of a Document.
+ * @property-read string $innerHTML
  */
 class Element extends \DOMElement {
 use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
@@ -24,11 +25,11 @@ public function querySelectorAll(string $selector):HTMLCollection {
 /**
  * returns true if the element would be selected by the specified selector
  * string; otherwise, returns false.
- * @param string $selector The CSS selector to check against
+ * @param string $selectors The CSS selector(s) to check against
  * @return bool True if this element is selectable by provided selector
  */
-public function matches(string $selector):bool {
-	$matches = $this->ownerDocument->querySelectorAll($selector);
+public function matches(string $selectors):bool {
+	$matches = $this->ownerDocument->querySelectorAll($selectors);
 	$i = $matches->length;
 	while(--$i >= 0 && $matches->item($i) !== $this);
 
@@ -51,7 +52,7 @@ public function getElementsByClassName(string $names):HTMLCollection {
 /**
  * Returns the closest ancestor of the current element (or itself)
  * which matches the selectors.
- * @param string $selectors CSS selectors
+ * @param string $selectors CSS selector(s)
  * @return Element|null
  */
 public function closest(string $selectors) {
@@ -60,7 +61,7 @@ public function closest(string $selectors) {
 }
 
 /**
- * @param string $selectors CSS selectors
+ * @param string $selectors CSS selector(s)
  * @param string $prefix
  * @return HTMLCollection
  */
@@ -98,6 +99,27 @@ public function prop_set_value($newValue) {
 	if(method_exists($this, $methodName)) {
 		return $this->$methodName($newValue);
 	}
+}
+
+public function prop_get_id():string {
+	return $this->getAttribute("id");
+}
+
+public function prop_set_id($newValue) {
+	$this->setAttribute("id", $newValue);
+}
+
+public function prop_get_innerHTML():string {
+	$childHtmlArray = [];
+	foreach($this->children as $child) {
+		$childHtmlArray []= $this->ownerDocument->saveHTML($child);
+	}
+
+	return implode(PHP_EOL, $childHtmlArray);
+}
+
+public function prop_get_outerHTML():string {
+	return $this->ownerDocument->saveHTML($this);
 }
 
 private function value_set_select($newValue) {

--- a/test/DomFragment.test.php
+++ b/test/DomFragment.test.php
@@ -72,4 +72,16 @@ public function testQuerySelector() {
 	$this->assertNull($fragment->querySelector(".third"));
 }
 
+public function testQuerySelectorAll() {
+	$document = new HTMLDocument(test\Helper::HTML);
+	$fragment = $document->createDocumentFragment();
+
+	$p1 = $document->createElement("p");
+	$p2 = $document->createElement("p");
+	$fragment->appendChild($p1);
+	$fragment->appendChild($p2);
+
+	$this->assertCount(2, $fragment->querySelectorAll("p"));
+}
+
 }#

--- a/test/DomFragment.test.php
+++ b/test/DomFragment.test.php
@@ -1,0 +1,38 @@
+<?php
+namespace Gt\Dom;
+
+
+class Test extends \PHPUnit_Framework_TestCase {
+
+/**
+ * Use the documentation example at
+ * https://developer.mozilla.org/docs/Web/API/Document/createDocumentFragment
+ */
+public function testFragmentCreates() {
+	$document = new HTMLDocument(test\Helper::HTML_LIST);
+	$ul = $document->getElementsByTagName("ul")[0];
+	$docfrag = $document->createDocumentFragment();
+	$browserList = [
+		"Internet Explorer",
+		"Firefox",
+		"Safari",
+		"Chrome",
+		"Opera",
+	];
+
+	foreach($browserList as $browser) {
+		$li = $document->createElement("li");
+		$li->textContent = $browser;
+		$docfrag->appendChild($li);
+	}
+
+	$ul->appendChild($docfrag);
+
+	$this->assertCount(count($browserList), $ul->children);
+	foreach($browserList as $browser) {
+		$this->assertContains($browser, $ul->textContent);
+	}
+}
+
+
+}#

--- a/test/DomFragment.test.php
+++ b/test/DomFragment.test.php
@@ -52,4 +52,24 @@ public function testGetElementById() {
 	$this->assertNull($fragment->getElementById("p3"));
 }
 
+public function testQuerySelector() {
+	$document = new HTMLDocument(test\Helper::HTML);
+	$fragment = $document->createDocumentFragment();
+
+	$p1 = $document->createElement("p");
+	$p1->className->add("test");
+	$p1->className->add("first");
+
+	$p2 = $document->createElement("p");
+	$p2->className->add("test");
+	$p2->className->add("second");
+
+	$fragment->appendChild($p1);
+	$fragment->appendChild($p2);
+
+	$this->assertSame($p1, $fragment->querySelector("p.test.first"));
+	$this->assertSame($p2, $fragment->querySelector(".second.test"));
+	$this->assertNull($fragment->getElementById(".third"));
+}
+
 }#

--- a/test/DomFragment.test.php
+++ b/test/DomFragment.test.php
@@ -57,19 +57,19 @@ public function testQuerySelector() {
 	$fragment = $document->createDocumentFragment();
 
 	$p1 = $document->createElement("p");
-	$p1->className->add("test");
-	$p1->className->add("first");
+	$p1->classList->add("test");
+	$p1->classList->add("first");
 
 	$p2 = $document->createElement("p");
-	$p2->className->add("test");
-	$p2->className->add("second");
+	$p2->classList->add("test");
+	$p2->classList->add("second");
 
 	$fragment->appendChild($p1);
 	$fragment->appendChild($p2);
 
 	$this->assertSame($p1, $fragment->querySelector("p.test.first"));
 	$this->assertSame($p2, $fragment->querySelector(".second.test"));
-	$this->assertNull($fragment->getElementById(".third"));
+	$this->assertNull($fragment->querySelector(".third"));
 }
 
 }#

--- a/test/DomFragment.test.php
+++ b/test/DomFragment.test.php
@@ -34,5 +34,22 @@ public function testFragmentCreates() {
 	}
 }
 
+public function testGetElementById() {
+	$document = new HTMLDocument(test\Helper::HTML);
+	$fragment = $document->createDocumentFragment();
+
+	$p1 = $document->createElement("p");
+	$p1->id = "p1";
+
+	$p2 = $document->createElement("p");
+	$p2->id = "p2";
+
+	$fragment->appendChild($p1);
+	$fragment->appendChild($p2);
+
+	$this->assertSame($p1, $fragment->getElementById("p1"));
+	$this->assertSame($p2, $fragment->getElementById("p2"));
+	$this->assertNull($fragment->getElementById("p3"));
+}
 
 }#

--- a/test/Helper.php
+++ b/test/Helper.php
@@ -78,6 +78,13 @@ const HTML_NESTED = <<<HTML
 </body>
 </html>
 HTML;
+
+const HTML_LIST = <<<HTML
+<!doctype html>
+<ul>
+</ul>
+HTML;
+
 const HTML_VALUE = <<<HTML
 <!doctype html>
 <html>


### PR DESCRIPTION
There are three methods documented on MDN which have been implemented and tested in this PR.

+ `DocumentFragment::querySelector()` Returns the first Element node within the DocumentFragment, in document order, that matches the specified selectors.
+ `DocumentFragment::querySelectorAll()` Returns a HTMLCollection of all the Element nodes within the DocumentFragment that match the specified selectors.
+ `DocumentFragment::getElementById()` Returns the first Element node within the DocumentFragment, in document order, that matches the specified ID.

This wasn't as simple as calling Element::querySelector as a DOMFragment is not an Element - it's a Node. Nodes do not have traversal methods on them like Elements do.

Implementation details:

+ Calling the methods in fact calls the method `callMethodOnTemporaryElement`, passing in the name of the method and the originally provided arguments.
+ A dummy element is created. All of the fragment's children are appended to the dummy element.
+ The methods of the Element are called (seeing as Element has the existing implementation of qs/qsa/gebi).
+ Because a DOM Node can only ever be the child of one parent, the child nodes are then reattached to the fragment, before the result is returned.

@j4m3s your views? 