### PR TITLE
Move querySelector[All] methods to ParentNode

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -11,19 +11,22 @@ use LiveProperty, ParentNode;
 
 public function __construct($document = null) {
 	parent::__construct("1.0", "utf-8");
-	$this->registerNodeClass("\\DOMNode", "\\Gt\\Dom\\Node");
-	$this->registerNodeClass("\\DOMElement", "\\Gt\\Dom\\Element");
-	$this->registerNodeClass("\\DOMAttr", "\\Gt\\Dom\\Attr");
-	$this->registerNodeClass("\\DOMDocumentFragment",
-		"\\Gt\\Dom\\DocumentFragment");
-	$this->registerNodeClass("\\DOMDocumentType", "\\Gt\\Dom\\DocumentType");
-	$this->registerNodeClass("\\DOMCharacterData", "\\Gt\\Dom\\CharacterData");
-	$this->registerNodeClass("\\DOMText", "\\Gt\\Dom\\Text");
-	$this->registerNodeClass("\\DOMComment", "\\Gt\\Dom\\Comment");
+	$this->registerNodeClass("\\DOMNode", Node::class);
+	$this->registerNodeClass("\\DOMElement", Element::class);
+	$this->registerNodeClass("\\DOMAttr", Attr::class);
+	$this->registerNodeClass("\\DOMDocumentFragment", DocumentFragment::class);
+	$this->registerNodeClass("\\DOMDocumentType", DocumentType::class);
+	$this->registerNodeClass("\\DOMCharacterData", CharacterData::class);
+	$this->registerNodeClass("\\DOMText", Text::class);
+	$this->registerNodeClass("\\DOMComment", Comment::class);
     if ($document instanceof \DOMDocument) {
         $this->appendChild($this->importNode($document->documentElement, true));
         return;
     }
 }
 
+protected  function getRootDocument(): \DOMDocument
+{
+    return $this;
+}
 };

--- a/src/DocumentFragment.php
+++ b/src/DocumentFragment.php
@@ -21,4 +21,8 @@ namespace Gt\Dom;
 class DocumentFragment extends \DOMDocumentFragment {
 use LiveProperty, ParentNode;
 
+protected function getRootDocument(): \DOMDocument
+{
+    return $this->ownerDocument;
+}
 }#

--- a/src/Element.php
+++ b/src/Element.php
@@ -15,16 +15,6 @@ use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
 /** @var  TokenList */
 private $liveProperty_classList;
 
-/** @return Element|null */
-public function querySelector(string $selector) {
-	$htmlCollection = $this->css($selector);
-	return $htmlCollection->item(0);
-}
-
-public function querySelectorAll(string $selector):HTMLCollection {
-	return $this->css($selector);
-}
-
 /**
  * returns true if the element would be selected by the specified selector
  * string; otherwise, returns false.
@@ -32,7 +22,7 @@ public function querySelectorAll(string $selector):HTMLCollection {
  * @return bool True if this element is selectable by provided selector
  */
 public function matches(string $selectors):bool {
-	$matches = $this->ownerDocument->querySelectorAll($selectors);
+	$matches = $this->getRootDocument()->querySelectorAll($selectors);
 	$i = $matches->length;
 	while(--$i >= 0 && $matches->item($i) !== $this);
 
@@ -63,22 +53,6 @@ public function closest(string $selectors) {
 	return $collection->item(count($collection) - 1);
 }
 
-/**
- * @param string $selectors CSS selector(s)
- * @param string $prefix
- * @return HTMLCollection
- */
-private function css(
-string $selectors, string $prefix = "descendant-or-self::"):HTMLCollection {
-	$converter = new CssSelectorConverter();
-	$xPathSelector = $converter->toXPath($selectors, $prefix);
-	return $this->xPath($xPathSelector);
-}
-
-private function xPath(string $selector):HTMLCollection {
-	$x = new DOMXPath($this->ownerDocument);
-	return new HTMLCollection($x->query($selector, $this));
-}
 
 public function prop_get_classList() {
 	if(!$this->liveProperty_classList) {
@@ -166,6 +140,11 @@ private function value_get_select() {
 	}
 
 	return $value;
+}
+
+protected  function getRootDocument(): \DOMDocument
+{
+    return $this->ownerDocument;
 }
 
 static public function isSelectOptionSelected(Element $option) {

--- a/src/HTMLDocument.php
+++ b/src/HTMLDocument.php
@@ -18,6 +18,8 @@ use DOMDocument;
  *  Links are <a> Elements with the `href` attribute.
  * @property-read HTMLCollection $scripts List of all <script> elements.
  * @property string $title The title of the document, defined using <title>.
+ * @method DocumentFragment createDocumentFragment(string) Create a new document fragment
+ *                         from an xml string
  */
 class HTMLDocument extends Document {
 use LiveProperty, ParentNode;
@@ -28,15 +30,6 @@ public function __construct($document) {
 	if(!($document instanceof DOMDocument)) {
 		$this->loadHTML($document);
 	}
-}
-
-/** @return Element|null */
-public function querySelector(string $selectors) {
-	return $this->documentElement->querySelector($selectors);
-}
-
-public function querySelectorAll(string $selectors):HTMLCollection {
-	return $this->documentElement->querySelectorAll($selectors);
 }
 
 public function getElementsByClassName(string $names):HTMLCollection {
@@ -90,7 +83,7 @@ private function prop_set_title($value) {
 }
 
 private function getOrCreateElement(string $tagName):Element {
-	$element = $this->documentElement->querySelector($tagName);
+	$element = $this->querySelector($tagName);
 	if(is_null($element)) {
 		$element = $this->createElement($tagName);
 		$this->documentElement->appendChild($element);
@@ -98,5 +91,4 @@ private function getOrCreateElement(string $tagName):Element {
 
 	return $element;
 }
-
 }#

--- a/src/ParentNode.php
+++ b/src/ParentNode.php
@@ -1,6 +1,9 @@
 <?php
 namespace Gt\Dom;
 
+use DOMXPath;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
 /**
  * Contains methods that are particular to Node objects that can have children.
  *
@@ -8,7 +11,7 @@ namespace Gt\Dom;
  *
  * This trait is used by the following classes:
  *  - Element
- *  - Document
+ *  - Document and its subclasses XMLDocument and HTMLDocument
  *  - DocumentFragment
  * @property-read HTMLCollection $children A live HTMLCollection containing all
  *  objects of type Element that are children of this ParentNode.
@@ -20,6 +23,18 @@ namespace Gt\Dom;
  *  ParentNode has.
  */
 trait ParentNode {
+
+/** @return Element|null */
+public function querySelector(string $selector)
+{
+    $htmlCollection = $this->css($selector);
+    return $htmlCollection->item(0);
+}
+
+public function querySelectorAll(string $selector): HTMLCollection
+{
+    return $this->css($selector);
+}
 
 private function prop_get_children():HTMLCollection {
 	return new HTMLCollection($this->childNodes);
@@ -36,5 +51,34 @@ private function prop_get_lastElementChild() {
 private function prop_get_childElementCount() {
 	return $this->children->length;
 }
+
+/**
+ * @param string $selectors CSS selector(s)
+ * @param string $prefix
+ *
+ * @return HTMLCollection
+ */
+public function css(
+    string $selectors,
+    string $prefix = "descendant-or-self::"
+): HTMLCollection {
+    $converter = new CssSelectorConverter();
+    $xPathSelector = $converter->toXPath($selectors, $prefix);
+    return $this->xPath($xPathSelector);
+}
+
+public function xPath(string $selector): HTMLCollection
+{
+    $x = new DOMXPath($this->getRootDocument());
+    return new HTMLCollection($x->query($selector, $this));
+}
+
+/**
+ * Normalises access to the parent dom document, which may be located in various places
+ * depending on what type of object is using the trait
+ *
+ * @return \DOMDocument
+ */
+protected abstract function getRootDocument(): \DOMDocument;
 
 }#

--- a/test/DocumentFragment.test.php
+++ b/test/DocumentFragment.test.php
@@ -3,8 +3,14 @@ namespace Gt\Dom;
 
 class DocumentFragmentTest extends \PHPUnit_Framework_TestCase {
 
-public function testQuerySelector() {
-	$document = new HTMLDocument();
+    const DOC_CONTENT_BEFORE_INSERT = "<!doctype html><body>"
+    . "<div><ul><li>outOfScope</li></ul></div>"
+    . "<span id='replaceWithSUT'></span>"
+    . "<div><ul><li>outOfScope</li></ul></div>"
+    . "</body>";
+
+public function testQuerySelectorBeforeBeforeAddingToDocument() {
+    $document = new HTMLDocument(self::DOC_CONTENT_BEFORE_INSERT);
 	$fragment = $document->createDocumentFragment();
 
 	$expectedFirstLi = null;
@@ -24,8 +30,8 @@ public function testQuerySelector() {
 	$this->assertSame($expectedFirstLi, $actualFirstLi);
 }
 
-public function testQuerySelectorAll() {
-	$document = new HTMLDocument();
+public function testQuerySelectorAllBeforeAddingToDocument() {
+    $document = new HTMLDocument(self::DOC_CONTENT_BEFORE_INSERT);
 	$fragment = $document->createDocumentFragment();
 
 	$expectedCount = 0;
@@ -41,26 +47,57 @@ public function testQuerySelectorAll() {
 	$this->assertCount($expectedCount, $liCollection);
 }
 
-public function testAppends() {
+public function testAppendsToDocument() {
 	$document = new HTMLDocument("<!doctype html><body><ul></ul></body>");
 	$fragment = $document->createDocumentFragment();
 
 	$expectedCount = 0;
+    $expectedFirstLi = null;
 	foreach(["Firefox", "Chrome", "Opera", "Safari", "Internet Explorer"]
 	as $browser) {
 		$expectedCount++;
 		$li = $document->createElement("li");
 		$li->textContent = $browser;
 		$fragment->appendChild($li);
+
+        if(is_null($expectedFirstLi)) {
+            $expectedFirstLi = $li;
+        }
 	}
 
 	$ul = $document->querySelector("ul");
 	$ul->appendChild($fragment);
 
-	$this->assertCount(
-		$expectedCount,
-		$document->querySelectorAll("body>ul>li")
-	);
+    $actualResult = $document->querySelectorAll("body>ul>li");
+    $this->assertCount($expectedCount, $actualResult);
+	$this->assertSame($expectedFirstLi, $actualResult[0]);
+}
+
+public function testQuerySelectorAfterAddingToDocument() {
+    $document = new HTMLDocument(
+        self::DOC_CONTENT_BEFORE_INSERT);
+
+    $fragment = $document->createDocumentFragment();
+    $fragment->appendXML("<ul><li>inScope</li></ul>");
+
+    $document->querySelector("span#replaceWithSUT")->replaceWith($fragment);
+
+    $actualResult = $fragment->querySelector("li");
+    $this->assertEquals("inScope", $actualResult->textContent);
+}
+
+public function testQuerySelectorAllAfterAddingToDocument() {
+    $document = new HTMLDocument(
+        self::DOC_CONTENT_BEFORE_INSERT);
+
+    $fragment = $document->createDocumentFragment();
+    $fragment->appendXML("<ul><li>inScope</li></ul>");
+
+    $document->querySelector("span#replaceWithSUT")->replaceWith($fragment);
+
+    $actualResult = $fragment->querySelectorAll("li");
+    $this->assertCount(1, $actualResult);
+    $this->assertEquals("inScope", $actualResult[0]->textContent);
 }
 
 }#

--- a/test/DocumentFragment.test.php
+++ b/test/DocumentFragment.test.php
@@ -83,6 +83,7 @@ public function testQuerySelectorAfterAddingToDocument() {
     $document->querySelector("span#replaceWithSUT")->replaceWith($fragment);
 
     $actualResult = $fragment->querySelector("li");
+    $this->assertNotNull($actualResult);
     $this->assertEquals("inScope", $actualResult->textContent);
 }
 

--- a/test/Element.test.php
+++ b/test/Element.test.php
@@ -10,9 +10,9 @@ public function testQuerySelector() {
 
 	$a = $document->querySelector("p>a");
 
-	$this->assertInstanceOf("\Gt\Dom\Element", $pAfterH2);
-	$this->assertInstanceOf("\Gt\Dom\Element", $aWithinP);
-	$this->assertInstanceOf("\Gt\Dom\Element", $a);
+	$this->assertInstanceOf(Element::class, $pAfterH2);
+	$this->assertInstanceOf(Element::class, $aWithinP);
+	$this->assertInstanceOf(Element::class, $a);
 	$this->assertSame($a, $aWithinP);
 }
 
@@ -71,8 +71,8 @@ public function testElementClosest() {
 	$innerPost = $document->querySelector("div.post.inner");
 	$innerListItem = $document->querySelector(".inner-item-1");
 	$outerPost = $document->querySelector("div.post.outer");
-	$this->assertInstanceOf("\Gt\Dom\Element", $innerPost);
-	$this->assertInstanceOf("\Gt\Dom\Element", $outerPost);
+	$this->assertInstanceOf(Element::class, $innerPost);
+	$this->assertInstanceOf(Element::class, $outerPost);
 
 	$closestDivToInnerListItem = $innerListItem->closest("div");
 	$closestDivToInnerPost = $innerPost->closest("div");


### PR DESCRIPTION
All works fine except the new tests I added to make sure that you can querySelect within a fragment after it's been appended to the Dom.  It seems reasonable to expect these methods to continue to work after inserting, but they don't - and I'm stuffed if I can figure out why. 

@g105b would you mind taking a look?