### PR TITLE
HTMLDocument constructor with no content

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -20,10 +20,12 @@ public function __construct($document = null) {
 	$this->registerNodeClass("\\DOMCharacterData", "\\Gt\\Dom\\CharacterData");
 	$this->registerNodeClass("\\DOMText", "\\Gt\\Dom\\Text");
 	$this->registerNodeClass("\\DOMComment", "\\Gt\\Dom\\Comment");
-    if ($document instanceof \DOMDocument) {
-        $this->appendChild($this->importNode($document->documentElement, true));
-        return;
-    }
+
+	if($document instanceof \DOMDocument) {
+		$node = $this->importNode($document->documentElement, true);
+		$this->appendChild($node);
+		return;
+	}
 }
 
 };

--- a/src/HTMLDocument.php
+++ b/src/HTMLDocument.php
@@ -26,7 +26,12 @@ public function __construct($document) {
 	parent::__construct($document);
 
 	if(!($document instanceof DOMDocument)) {
-		$this->loadHTML($document);
+		if(empty($document)) {
+			$this->fillEmptyDocumentElement();
+		}
+		else {
+			$this->loadHTML($document);
+		}
 	}
 }
 
@@ -97,6 +102,16 @@ private function getOrCreateElement(string $tagName):Element {
 	}
 
 	return $element;
+}
+
+private function fillEmptyDocumentElement() {
+	$this->loadHTML("<!doctype html><html></html>");
+	$tagsToCreate = ["head", "body"];
+
+	foreach($tagsToCreate as $tag) {
+		$node = $this->createElement($tag);
+		$this->documentElement->appendChild($node);
+	}
 }
 
 }#

--- a/test/HTMLDocument.test.php
+++ b/test/HTMLDocument.test.php
@@ -142,4 +142,13 @@ public function testTitleWhenNoTitle() {
 	$this->assertEquals($newTitle, $document->title);
 }
 
+public function testEmptyHTMLDocument() {
+	$document = new HTMLDocument("");
+	$nothing = $document->querySelector("div");
+	$this->assertNull($nothing);
+	$this->assertCount(2, $document->documentElement->children);
+	$this->assertNotNull($document->head);
+	$this->assertNotNull($document->body);
+}
+
 }#


### PR DESCRIPTION
Fixes the issues caused by creating an empty HTMLDocument by creating the bare bones HTML, replicating the functionality in JavaScript.