### PR TITLE
Use scope resolution operator everywhere, closes #89

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -1,5 +1,13 @@
 <?php
 namespace Gt\Dom;
+use DOMAttr;
+use DOMCharacterData;
+use DOMComment;
+use DOMDocumentFragment;
+use DOMDocumentType;
+use DOMElement;
+use DOMNode;
+use DOMText;
 
 /**
  * Represents any web page loaded in the browser and serves as an entry point
@@ -11,14 +19,14 @@ use LiveProperty, ParentNode;
 
 public function __construct($document = null) {
 	parent::__construct("1.0", "utf-8");
-	$this->registerNodeClass("\\DOMNode", Node::class);
-	$this->registerNodeClass("\\DOMElement", Element::class);
-	$this->registerNodeClass("\\DOMAttr", Attr::class);
-	$this->registerNodeClass("\\DOMDocumentFragment", DocumentFragment::class);
-	$this->registerNodeClass("\\DOMDocumentType", DocumentType::class);
-	$this->registerNodeClass("\\DOMCharacterData", CharacterData::class);
-	$this->registerNodeClass("\\DOMText", Text::class);
-	$this->registerNodeClass("\\DOMComment", Comment::class);
+	$this->registerNodeClass(DOMNode::class, Node::class);
+	$this->registerNodeClass(DOMElement::class, Element::class);
+	$this->registerNodeClass(DOMAttr::class, Attr::class);
+	$this->registerNodeClass(DOMDocumentFragment::class, DocumentFragment::class);
+	$this->registerNodeClass(DOMDocumentType::class, DocumentType::class);
+	$this->registerNodeClass(DOMCharacterData::class, CharacterData::class);
+	$this->registerNodeClass(DOMText::class, Text::class);
+	$this->registerNodeClass(DOMComment::class, Comment::class);
 
 	if ($document instanceof \DOMDocument) {
 		$node = $this->importNode($document->documentElement, true);

--- a/test/Element.test.php
+++ b/test/Element.test.php
@@ -56,16 +56,16 @@ public function testElementClosest() {
 	$document = new HTMLDocument(test\Helper::HTML_NESTED);
 
 	$p = $document->querySelector('.inner-list p');
-	$this->assertInstanceOf('\Gt\Dom\Element', $p);
+	$this->assertInstanceOf(Element::class, $p);
 
 	$innerList = $document->querySelector('.inner-list');
-	$this->assertInstanceOf('\Gt\Dom\Element', $innerList);
+	$this->assertInstanceOf(Element::class, $innerList);
 
 	$closestUl = $innerList->closest('ul');
 	$this->assertEquals($innerList, $closestUl);
 
 	$container = $p->closest('.container');
-	$this->assertInstanceOf('\Gt\Dom\Element', $container);
+	$this->assertInstanceOf(Element::class, $container);
 
 	$nonExistentClosestElement = $p->closest('br');
 	$this->assertNull($nonExistentClosestElement);

--- a/test/HTMLCollection.test.php
+++ b/test/HTMLCollection.test.php
@@ -1,11 +1,14 @@
 <?php
 namespace Gt\Dom;
 
+use ArrayAccess;
+use DOMNodeList;
+
 class HTMLCollectionTest extends \PHPUnit_Framework_TestCase {
 
 public function testType() {
 	$document = new HTMLDocument(test\Helper::HTML);
-	$this->assertInstanceOf("\Gt\Dom\HTMLCollection", $document->children);
+	$this->assertInstanceOf(HTMLCollection::class, $document->children);
 }
 
 public function testNonElementsRemoved() {
@@ -13,11 +16,11 @@ public function testNonElementsRemoved() {
 	$bodyChildNodes = $document->body->childNodes;
 	$bodyChildren = $document->body->children;
 
-	$this->assertInstanceOf("\DOMNodeList", $bodyChildNodes);
-	$this->assertInstanceOf("\Gt\Dom\HTMLCollection", $bodyChildren);
+	$this->assertInstanceOf(DOMNodeList::class, $bodyChildNodes);
+	$this->assertInstanceOf(HTMLCollection::class, $bodyChildren);
 
-	$this->assertInstanceOf("\Gt\Dom\Text", $bodyChildNodes->item(0));
-	$this->assertInstanceOf("\Gt\Dom\Element", $bodyChildren->item(0));
+	$this->assertInstanceOf(Text::class, $bodyChildNodes->item(0));
+	$this->assertInstanceOf(Element::class, $bodyChildren->item(0));
 }
 
 public function testArrayAccessImplementation() {
@@ -25,14 +28,14 @@ public function testArrayAccessImplementation() {
 	$collection = $document->body->children;
 
 // test if the collection implements ArrayAccess
-	$this->assertInstanceOf('\ArrayAccess', $collection);
+	$this->assertInstanceOf(ArrayAccess::class, $collection);
 
 // test if offset 0 exists
 	$this->assertArrayHasKey(0, $collection);
 
 // test if the first item is an Element instance
 	$first = $collection[0];
-	$this->assertInstanceOf('\Gt\Dom\Element', $first);
+	$this->assertInstanceOf(Element::class, $first);
 
 // test if the collection is read only
 	$this->setExpectedException(\BadMethodCallException::class);

--- a/test/HTMLDocument.test.php
+++ b/test/HTMLDocument.test.php
@@ -1,23 +1,25 @@
 <?php
 namespace Gt\Dom;
 
+use DOMDocument;
+
 class HTMLDocumentTest extends \PHPUnit_Framework_TestCase {
 
 public function testConstruction()
 {
 // test construction from raw HTML
 	$fromRawHTML = new HTMLDocument(test\Helper::HTML);
-	$this->assertInstanceOf('Gt\Dom\HTMLDocument', $fromRawHTML);
+	$this->assertInstanceOf(HTMLDocument::class, $fromRawHTML);
 
 // test construction from a DOMDocument object
-	$domDocument = new \DOMDocument('1.0', 'UTF-8');
+	$domDocument = new DOMDocument('1.0', 'UTF-8');
 	$domDocument->loadHTML(test\Helper::HTML);
 	$fromDOMDocument = new HTMLDocument($domDocument);
-	$this->assertInstanceOf('Gt\Dom\HTMLDocument', $fromDOMDocument);
+	$this->assertInstanceOf(HTMLDocument::class, $fromDOMDocument);
 
 // test construction from a HTMLDocument object, just to be sure
 	$fromHTMLDocument = new HTMLDocument($fromRawHTML);
-	$this->assertInstanceOf('Gt\Dom\HTMLDocument', $fromHTMLDocument);
+	$this->assertInstanceOf(HTMLDocument::class, $fromHTMLDocument);
 
 // test if elements are consistent
 	$h2FromRawHTML = $fromRawHTML->querySelector('h2');
@@ -28,7 +30,7 @@ public function testConstruction()
 
 public function testInheritance() {
 	$document = new HTMLDocument(test\Helper::HTML);
-	$this->assertInstanceOf("Gt\Dom\Element", $document->documentElement);
+	$this->assertInstanceOf(Element::class, $document->documentElement);
 }
 
 public function testRemoveElement() {
@@ -68,24 +70,24 @@ public function testQuerySelectorAll() {
 
 public function testHeadElement() {
 	$document = new HTMLDocument(test\Helper::HTML_MORE);
-	$this->assertInstanceOf("\Gt\Dom\Element", $document->head);
+	$this->assertInstanceOf(Element::class, $document->head);
 }
 
 public function testHeadElementAutomaticallyCreated() {
 // test\Helper::HTML does not explicitly define a <head>
 	$document = new HTMLDocument(test\Helper::HTML);
-	$this->assertInstanceOf("\Gt\Dom\Element", $document->head);
+	$this->assertInstanceOf(Element::class, $document->head);
 }
 
 public function testBodyElement() {
 	$document = new HTMLDocument(test\Helper::HTML_MORE);
-	$this->assertInstanceOf("\Gt\Dom\Element", $document->body);
+	$this->assertInstanceOf(Element::class, $document->body);
 }
 
 public function testBodyElementAutomaticallyCreated() {
 // test\Helper::HTML does not explicitly define a <body>
 	$document = new HTMLDocument(test\Helper::HTML);
-	$this->assertInstanceOf("\Gt\Dom\Element", $document->body);
+	$this->assertInstanceOf(Element::class, $document->body);
 }
 
 // Test live properties:

--- a/test/NonDocumentTypeChildNode.test.php
+++ b/test/NonDocumentTypeChildNode.test.php
@@ -14,8 +14,7 @@ public function testElementSiblings() {
 		$whoHeading->nextElementSibling->nextElementSibling);
 	$this->assertSame($plugParagraph, $whoHeading->previousElementSibling);
 
-	$this->assertInstanceOf(
-		"\Gt\Dom\Element", $formsAnchor);
+	$this->assertInstanceOf(Element::class, $formsAnchor);
 
 	$firstImg = $document->querySelector("img");
 	$this->assertEquals("h1", $firstImg->previousElementSibling->tagName);

--- a/test/ParentNode.test.php
+++ b/test/ParentNode.test.php
@@ -16,17 +16,17 @@ public function testChildren() {
 public function testFirstLastElementChild() {
 	$document = new HTMLDocument(test\Helper::HTML_MORE);
 	$this->assertInstanceOf(
-		"\Gt\Dom\Text", $document->body->firstChild);
+		Text::class, $document->body->firstChild);
 	$this->assertInstanceOf(
-		"\Gt\Dom\Element", $document->body->firstElementChild);
+		Element::class, $document->body->firstElementChild);
 }
 
 public function testChildElementCount() {
 	$document = new HTMLDocument(test\Helper::HTML_MORE);
 	$this->assertInstanceOf(
-		"\Gt\Dom\Text", $document->body->lastChild);
+		Text::class, $document->body->lastChild);
 	$this->assertInstanceOf(
-		"\Gt\Dom\Element", $document->body->lastElementChild);
+		Element::class, $document->body->lastElementChild);
 }
 
 }#

--- a/test/XMLDocument.test.php
+++ b/test/XMLDocument.test.php
@@ -6,17 +6,17 @@ class XMLDocumentTest extends \PHPUnit_Framework_TestCase {
 public function testConstruction() {
 	// test construction from raw XML
 	$fromRawXML = new XMLDocument(test\Helper::XML);
-	$this->assertInstanceOf('Gt\Dom\XMLDocument', $fromRawXML);
+	$this->assertInstanceOf(XMLDocument::class, $fromRawXML);
 	// test construction from a DOMDocument object
 	$domDocument = new \DOMDocument('1.0', 'UTF-8');
 	$domDocument->loadXML(test\Helper::XML);
 
 	$fromDOMDocument = new XMLDocument($domDocument);
-	$this->assertInstanceOf('Gt\Dom\XMLDocument', $fromDOMDocument);
+	$this->assertInstanceOf(XMLDocument::class, $fromDOMDocument);
 
 	// test construction from a XMLDocument object, just to be sure
 	$fromXMLDocument = new XMLDocument($fromRawXML);
-	$this->assertInstanceOf('Gt\Dom\XMLDocument', $fromXMLDocument);
+	$this->assertInstanceOf(XMLDocument::class, $fromXMLDocument);
 
 }
 


### PR DESCRIPTION
Wherever fully qualified class names were used in strings such as `"\\DOMDocument" or "\\Gt\Dom\Document", the SRO has been used e.g. `DOMDocument::class`