### PR TITLE
DocBlocks added to overridden classes to help IDEs

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -1,10 +1,13 @@
 <?php
 namespace Gt\Dom;
+use DOMNode;
 
 /**
  * Represents any web page loaded in the browser and serves as an entry point
  * into the web page's content, the DOM tree (including elements such as
  * <body> or <table>).
+ *
+ * @method Node importNode(DOMNode $importedNode, bool $deep = false)
  */
 class Document extends \DOMDocument {
 use LiveProperty, ParentNode;

--- a/src/Document.php
+++ b/src/Document.php
@@ -7,7 +7,10 @@ use DOMNode;
  * into the web page's content, the DOM tree (including elements such as
  * <body> or <table>).
  *
+ * @method DocumentFragment createDocumentFragment(string) Create a new document fragment
+ * from an xml string
  * @method Node importNode(DOMNode $importedNode, bool $deep = false)
+ * @method NodeList getElementsByTagName(string $name)
  */
 class Document extends \DOMDocument {
 use LiveProperty, ParentNode;

--- a/src/Element.php
+++ b/src/Element.php
@@ -25,7 +25,7 @@ use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
 /** @var  TokenList */
 private $liveProperty_classList;
 
-/**
+	/**
  * returns true if the element would be selected by the specified selector
  * string; otherwise, returns false.
  * @param string $selectors The CSS selector(s) to check against

--- a/src/Element.php
+++ b/src/Element.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Dom;
 
+use DOMDocument;
 use DOMElement;
 use DOMXPath;
 use Symfony\Component\CssSelector\CssSelectorConverter;
@@ -21,11 +22,12 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  * parsed from the given string
  */
 class Element extends DOMElement {
+use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
 
 /** @var  TokenList */
 private $liveProperty_classList;
 
-	/**
+/**
  * returns true if the element would be selected by the specified selector
  * string; otherwise, returns false.
  * @param string $selectors The CSS selector(s) to check against
@@ -137,6 +139,10 @@ public function prop_set_outerHTML(string $html) {
 	$this->replaceWith($fragment);
 }
 
+protected  function getRootDocument(): DOMDocument {
+	return $this->ownerDocument;
+}
+
 private function value_set_select(string $newValue) {
 	$options = $this->getElementsByTagName('option');
 	$selectedIndexes = [];
@@ -178,11 +184,6 @@ private function value_get_select() : string {
 	}
 
 	return $value;
-}
-
-protected  function getRootDocument(): \DOMDocument
-{
-    return $this->ownerDocument;
 }
 
 private function value_set_input(string $newValue) {

--- a/src/Element.php
+++ b/src/Element.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Dom;
 
+use DOMElement;
 use DOMXPath;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
@@ -19,8 +20,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  * element and its descendants. It can be set to replace the element with nodes
  * parsed from the given string
  */
-class Element extends \DOMElement {
-use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
+class Element extends DOMElement {
 
 /** @var  TokenList */
 private $liveProperty_classList;

--- a/src/HTMLCollection.php
+++ b/src/HTMLCollection.php
@@ -1,11 +1,6 @@
 <?php
 namespace Gt\Dom;
 
-use Iterator;
-use ArrayAccess;
-use Countable;
-use DOMNodeList;
-
 /**
  * Represents a Node list that can only contain Element nodes. Internally,
  * a DOMNodeList is used to store the association to the original list of
@@ -13,33 +8,7 @@ use DOMNodeList;
  * that are Elements.
  * @property-read int $length Number of Element nodes in this collection
  */
-class HTMLCollection implements Iterator, ArrayAccess, Countable {
-use LiveProperty;
-
-private $domNodeList;
-private $key = 0;
-
-public function __construct(DOMNodeList $domNodeList) {
-	$this->domNodeList = $domNodeList;
-}
-
-/**
- * Gets the nth Element object in the internal DOMNodeList.
- * @param int $index
- * @return Element|null
- */
-public function item(int $index) {
-	$count = 0;
-	foreach($this as $element) {
-		if($index === $count) {
-			return $element;
-		}
-
-		$count++;
-	}
-
-	return null;
-}
+class HTMLCollection extends NodeList {
 
 /**
  * @param string $name Returns the specific Node whose ID or, as a fallback,
@@ -64,83 +33,6 @@ public function namedItem(string $name) {
 	}
 
 	return $namedElement;
-}
-
-/**
- * Returns the number of Elements contained in this Collection. Exposed as the
- * $length property.
- * @return int Number of Elements
- */
-private function prop_get_length():int {
-	$length = 0;
-	foreach($this as $element) {
-		$length++;
-	}
-
-	return $length;
-}
-
-public function count():int {
-	return $this->length;
-}
-
-// Iterator --------------------------------------------------------------------
-
-public function current():Element {
-	return $this->domNodeList[$this->key];
-}
-
-public function key():int {
-	return $this->key;
-}
-
-public function next() {
-	$this->key++;
-	$this->incrementKeyToNextElement();
-}
-
-public function rewind() {
-	$this->key = 0;
-	$this->incrementKeyToNextElement();
-}
-
-public function valid():bool {
-	return isset($this->domNodeList[$this->key]);
-}
-
-private function incrementKeyToNextElement() {
-	while($this->valid()
-	&& !$this->domNodeList[$this->key] instanceof Element) {
-		$this->key++;
-	}
-}
-
-// ArrayAccess -----------------------------------------------------------------
-
-/**
- * Offset exists?
- * @param integer $offset offset number
- * @return boolean
- */
-public function offsetExists($offset):bool {
-	return isset($offset, $this->domNodeList);
-}
-
-/**
- * Returns the element in the offset position
- * @param integer $offset offset number
- * @return Element
- */
-public function offsetGet($offset):Element {
-	return $this->item($offset);
-}
-
-public function offsetSet($offset, $value) {
-	return $this->offsetUnset($offset);
-}
-
-public function offsetUnset($offset) {
-	throw new \BadMethodCallException("HTMLCollection's items are read only");
 }
 
 }#

--- a/src/HTMLDocument.php
+++ b/src/HTMLDocument.php
@@ -18,8 +18,6 @@ use DOMDocument;
  *  Links are <a> Elements with the `href` attribute.
  * @property-read HTMLCollection $scripts List of all <script> elements.
  * @property string $title The title of the document, defined using <title>.
- * @method DocumentFragment createDocumentFragment(string) Create a new document fragment
- *                         from an xml string
  */
 class HTMLDocument extends Document {
 use LiveProperty, ParentNode;

--- a/src/Node.php
+++ b/src/Node.php
@@ -21,4 +21,9 @@ use DOMNode;
  */
 class Node extends DOMNode {
 use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
+
+protected  function getRootDocument(): DOMDocument {
+	return $this->ownerDocument;
+}
+
 }#

--- a/src/Node.php
+++ b/src/Node.php
@@ -1,8 +1,22 @@
 <?php
 namespace Gt\Dom;
 
+use DOMNode;
+
 /**
  * A Node is an interface from which a number of DOM types inherit, and allows
- * these various types to be treated (or tested) similarly.
+ * these various types to be treated (or tested) similarly
+ *
+ * @method Node appendChild(DOMNode $newnode)
+ * @method Node cloneNode(bool $deep = false)
+ * @method Node insertBefore(DOMNode $newnode, DOMNode $refnode = null)
+ * @method Node removeChild(DOMNode $oldnode)
+ * @method Node replaceChild(DOMNode $newnode, DOMNode $oldnode)
+ *
+ * @property-read Node $parentNode
+ * @property-read Node $firstChild
+ * @property-read Node $lastChild
+ * @property-read Node $previousSibling
+ * @property-read Node $nextSibling
  */
-class Node extends \DOMNode {}#
+class Node extends DOMNode {}#

--- a/src/Node.php
+++ b/src/Node.php
@@ -19,4 +19,6 @@ use DOMNode;
  * @property-read Node $previousSibling
  * @property-read Node $nextSibling
  */
-class Node extends DOMNode {}#
+class Node extends DOMNode {
+use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
+}#

--- a/src/NodeList.php
+++ b/src/NodeList.php
@@ -1,0 +1,122 @@
+<?php
+namespace Gt\Dom;
+
+use DOMNodeList;
+use ArrayAccess;
+use Countable;
+use Iterator;
+
+class NodeList implements Iterator, ArrayAccess, Countable {
+
+use LiveProperty;
+
+private $domNodeList;
+
+public function __construct(DOMNodeList $domNodeList) {
+	$this->domNodeList = $domNodeList;
+}
+
+/**
+ * Returns the number of Elements contained in this Collection. Exposed as the
+ * $length property.
+ * @return int Number of Elements
+ */
+private function prop_get_length():int {
+	$length = 0;
+	foreach($this as $element) {
+		$length++;
+	}
+
+	return $length;
+}
+
+public function getDomNodeList():DOMNodeList {
+	return $this->domNodeList;
+}
+
+/**
+ * Gets the nth Element object in the internal DOMNodeList.
+ * @param int $index
+ * @return Element|null
+ */
+public function item($index) {
+	$count = 0;
+	foreach($this as $element) {
+		if($index === $count) {
+			return $element;
+		}
+
+		$count++;
+	}
+
+	return null;
+}
+
+// Iterator --------------------------------------------------------------------
+
+private $key = 0;
+
+public function current():Element {
+	return $this->domNodeList[$this->key];
+}
+
+public function key():int {
+	return $this->key;
+}
+
+public function next() {
+	$this->key++;
+	$this->incrementKeyToNextElement();
+}
+
+public function rewind() {
+	$this->key = 0;
+	$this->incrementKeyToNextElement();
+}
+
+public function valid():bool {
+	return isset($this->domNodeList[$this->key]);
+}
+
+private function incrementKeyToNextElement() {
+	while($this->valid()
+	&& !$this->domNodeList[$this->key] instanceof Element) {
+		$this->key++;
+	}
+}
+
+// ArrayAccess -----------------------------------------------------------------
+
+/**
+ * Offset exists?
+ * @param integer $offset offset number
+ * @return boolean
+ */
+public function offsetExists($offset):bool {
+	return isset($offset, $this->domNodeList);
+}
+
+/**
+ * Returns the element in the offset position
+ * @param integer $offset offset number
+ * @return Element
+ */
+public function offsetGet($offset):Element {
+	return $this->item($offset);
+}
+
+public function offsetSet($offset, $value) {
+	return $this->offsetUnset($offset);
+}
+
+public function offsetUnset($offset) {
+	throw new \BadMethodCallException("HTMLCollection's items are read only");
+}
+
+// Countable -------------------------------------------------------------------
+
+public function count():int {
+	return $this->length;
+}
+
+}#

--- a/src/ParentNode.php
+++ b/src/ParentNode.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  *  child of this ParentNode.
  * @property-read int $childElementCount The amount of children that the
  *  ParentNode has.
+ *
+ * @method Node getElementById(string $id)
  */
 trait ParentNode {
 

--- a/src/ParentNode.php
+++ b/src/ParentNode.php
@@ -73,6 +73,15 @@ public function xPath(string $selector): HTMLCollection
     return new HTMLCollection($x->query($selector, $this));
 }
 
+public function getElementsByTagName($name) {
+	$nodeList = parent::getElementsByTagName($name);
+	if($nodeList instanceof NodeList) {
+		return $nodeList;
+	}
+
+	return new NodeList($nodeList);
+}
+
 /**
  * Normalises access to the parent dom document, which may be located in various places
  * depending on what type of object is using the trait

--- a/test/Element.test.php
+++ b/test/Element.test.php
@@ -195,4 +195,32 @@ public function testTextContentDoesNotAffectChildElements() {
     }
 }
 
+/**
+ * The test passes, but IDEs do not show the correct types.
+ */
+public function testNodeFunctionsReturnGtObjects() {
+	$objectsThatShouldBeElements = [];
+	$document = new HTMLDocument(test\Helper::HTML);
+	$h1 = $document->querySelector("h1");
+	$objectsThatShouldBeElements["h1"] = $h1;
+	$objectsThatShouldBeElements["h1Clone"] = $h1->cloneNode(true);
+	$objectsThatShouldBeElements["parent"] = $h1->parentNode;
+	$objectsThatShouldBeElements["firstChild"] = $document->body->firstChild;
+
+	$otherDocument = new HTMLDocument();
+	$otherDiv = $otherDocument->createElement("div");
+	$objectsThatShouldBeElements["imported"] = $document->importNode($otherDiv);
+	$objectsThatShouldBeElements["imported-appended"] = $document->appendChild(
+		$objectsThatShouldBeElements["imported"]);
+
+	$test = $objectsThatShouldBeElements["imported"];
+
+	foreach($objectsThatShouldBeElements as $key => $object) {
+		$this->assertInstanceOf(
+			Element::class,
+			$object,
+			"$key instance of " . gettype($object));
+	}
+}
+
 }#

--- a/test/Element.test.php
+++ b/test/Element.test.php
@@ -186,7 +186,7 @@ public function testTextContentDoesNotAffectChildElements() {
     $document = new HTMLDocument(test\Helper::HTML_MORE);
     $firstParagraph = $document->querySelector("p");
     $firstParagraph->innerText = "<span>Example</span>";
-
+// TODO: Check that the childNodes property ends up as a Gt Dom HTMLCollection
     $this->assertGreaterThan(0, count($firstParagraph->childNodes));
 
     foreach($firstParagraph->childNodes as $child) {
@@ -212,8 +212,6 @@ public function testNodeFunctionsReturnGtObjects() {
 	$objectsThatShouldBeElements["imported"] = $document->importNode($otherDiv);
 	$objectsThatShouldBeElements["imported-appended"] = $document->appendChild(
 		$objectsThatShouldBeElements["imported"]);
-
-	$test = $objectsThatShouldBeElements["imported"];
 
 	foreach($objectsThatShouldBeElements as $key => $object) {
 		$this->assertInstanceOf(

--- a/test/NodeList.test.php
+++ b/test/NodeList.test.php
@@ -1,0 +1,20 @@
+<?php
+namespace Gt\Dom;
+
+class NodeListTest extends \PHPUnit_Framework_TestCase {
+
+public function testNodeListFunctionsReturnGtObjects() {
+	$objectsThatShouldBeNodeList = [];
+	$document = new HTMLDocument(test\Helper::HTML_MORE);
+
+	$objectsThatShouldBeNodeList["tag-name"] = $document->getElementsByTagName("p");
+
+	foreach($objectsThatShouldBeNodeList as $key => $object) {
+		$this->assertInstanceOf(
+			NodeList::class,
+			$object,
+			"$key instance of " . gettype($object));
+	}
+}
+
+}#


### PR DESCRIPTION
This PR has many additions to doc blocks, but also a rejig of the way certain classes/traits are inherited to more closely match how the inheritance works in dom.spec.whatwg.org

@j4m3s you were experiencing this issue a while back, would you mind checking to see if your types are correctly annotated now?