### PR TITLE
Add __toString method to Document, Fixes #86

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -39,4 +39,8 @@ protected  function getRootDocument(): \DOMDocument {
 	return $this;
 }
 
+public function __toString(){
+    return $this->saveHTML();
+}
+
 }#


### PR DESCRIPTION
This commit adds a toString method to Document.php, allowing one to use `echo $document` instead of `echo $document->saveHTML()