### PR TITLE
Fixed getting ID by a magic __get access

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -113,7 +113,7 @@ class Element extends DOMElement {
 		}
 	}
 
-	public function prop_get_id():string {
+	public function prop_get_id():?string {
 		return $this->getAttribute("id");
 	}
 

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -237,4 +237,17 @@ class ElementTest extends TestCase {
 		$h1->innerText = "Goodbye!";
 		$this->assertEquals("Goodbye!", $h1->textContent);
 	}
+
+    public function testGetNonExistingIdGivesNull() {
+        $document = new HTMLDocument(Helper::HTML);
+        $body = $document->getElementsByTagName("body")[0] ?? null;
+        self::assertNotNull($body);
+        /** @var Element $body */
+        $idByGetAttribute = $body->getAttribute('id');
+        self::assertNull($idByGetAttribute);
+        $idByPropGetId = $body->prop_get_id();
+        self::assertNull($idByPropGetId);
+        $idByMagicGet = $body->id;
+        self::assertNull($idByMagicGet);
+	}
 }


### PR DESCRIPTION
Hi, I have met a fatal error caused by `Element->prop_get_id()` method, which has been broken by commit 84d9d2e486c289832bf1292ed68c6474fd55a680 and affects stable version 1.0.2

It has been caused by a strict return type :string, without NULL allowed, but NULL can happen as an element can exists without ID and as it calls `getAttribute($name):?string` in background (notice the question mark, NULL allowed).

The fix was simple, just allowing NULL as a return type for `Element->prop_get_id():?string`.

Thank you for making your library free and public.