### PR TITLE
Implement Element::dataset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 
 	"require-dev": {
-		"phpunit/phpunit": "^6.4|^7.0"
+		"phpunit/phpunit": "^7.0"
 	},
 
 	"license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 
 	"require": {
 		"php": ">=7.1.0",
+		"ext-dom": "*",
 		"symfony/css-selector": "3.2.*"
 	},
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5a1fcaac7cf7701d2c9bb1716cf6221",
+    "content-hash": "b055bdc0ccc6cc72e15866dfc7e1deda",
     "packages": [
         {
             "name": "symfony/css-selector",
@@ -1476,7 +1476,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "ext-dom": "*"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c74335a1ee8374fb72e477d8b7c36163",
+    "content-hash": "d5a1fcaac7cf7701d2c9bb1716cf6221",
     "packages": [
         {
             "name": "symfony/css-selector",
@@ -545,20 +545,23 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cecbc684605bb0cc288828eb5d65d93d5c676d3c",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
@@ -588,7 +591,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-06-11T11:44:00+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",

--- a/src/Element.php
+++ b/src/Element.php
@@ -9,6 +9,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 /**
  * The most general base class from which all objects in a Document inherit.
  *
+ * @property-read Attr[] $attributes
  * @property string $className Gets and sets the value of the class attribute
  * @property-read TokenList $classList Returns a live TokenList collection of
  * the class attributes of the element
@@ -21,12 +22,15 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  * element and its descendants. It can be set to replace the element with nodes
  * parsed from the given string
  * @property string $innerText
+ * @property-read StringMap $dataset
  */
 class Element extends DOMElement {
 	use LiveProperty, NonDocumentTypeChildNode, ChildNode, ParentNode;
 
 	/** @var  TokenList */
-	private $liveProperty_classList;
+	protected $liveProperty_classList;
+	/** @var StringMap */
+	protected $liveProperty_dataset;
 
 	/**
 	 * returns true if the element would be selected by the specified selector
@@ -181,6 +185,21 @@ class Element extends DOMElement {
 	public function prop_set_innerText(string $value):string {
 		$this->textContent = $value;
 		return $this->textContent;
+	}
+
+	public function prop_get_dataset():StringMap {
+		if(empty($this->liveProperty_dataset)) {
+			$this->liveProperty_dataset = $this->createDataset();
+		}
+
+		return $this->liveProperty_dataset;
+	}
+
+	protected function createDataset():StringMap {
+		return new StringMap(
+			$this,
+			$this->attributes
+		);
 	}
 
 	protected function getRootDocument():DOMDocument {

--- a/src/StringMap.php
+++ b/src/StringMap.php
@@ -89,7 +89,7 @@ class StringMap implements ArrayAccess {
 	 * @link https://php.net/manual/en/arrayaccess.offsetexists.php
 	 */
 	public function offsetExists($offset):bool {
-		return $this->__isset($this->properties[$offset]);
+		return $this->__isset($offset);
 	}
 
 	/**

--- a/src/StringMap.php
+++ b/src/StringMap.php
@@ -1,0 +1,133 @@
+<?php
+namespace Gt\Dom;
+
+use ArrayAccess;
+
+class StringMap implements ArrayAccess {
+	/** @var Element */
+	protected $ownerElement;
+	/** @var array */
+	protected $properties;
+
+	/**
+	 * @param Attr[] $attributes
+	 */
+	public function __construct(
+		Element $ownerElement,
+		$attributes,
+		string $prefix = "data-"
+	) {
+		$this->ownerElement = $ownerElement;
+		$this->properties = [];
+
+		foreach($attributes as $attr) {
+			if(strpos($attr->name, $prefix) !== 0) {
+				continue;
+			}
+
+			$propName = $this->getPropertyName($attr);
+			$this->properties[$propName] = $attr->value;
+		}
+	}
+
+	public function __get(string $name):?string {
+		return $this->properties[$name] ?? null;
+	}
+
+	public function __set(string $name, string $value):void {
+		$this->properties[$name] = $value;
+
+		foreach($this->properties as $key => $value) {
+			$this->ownerElement->setAttribute(
+				$this->getAttributeName($key),
+				$value
+			);
+		}
+	}
+
+	protected function getPropertyName(Attr $attr):string {
+		$name = "";
+		$nameParts = explode("-", $attr->name);
+
+		foreach($nameParts as $i => $part) {
+			if($i === 0) {
+				continue;
+			}
+
+			if($i > 1) {
+				$part = ucfirst($part);
+			}
+
+			$name .= $part;
+		}
+
+		return $name;
+	}
+
+	protected function getAttributeName(string $propName):string {
+		$nameParts = preg_split(
+			"/(?=[A-Z])/",
+			$propName
+		);
+		array_unshift($nameParts, "data");
+		return implode("-", $nameParts);
+	}
+
+	/**
+	 * Whether a offset exists
+	 * @link https://php.net/manual/en/arrayaccess.offsetexists.php
+	 * @param mixed $offset <p>
+	 * An offset to check for.
+	 * </p>
+	 * @return boolean true on success or false on failure.
+	 * </p>
+	 * <p>
+	 * The return value will be casted to boolean if non-boolean was returned.
+	 * @since 5.0.0
+	 */
+	public function offsetExists($offset) {
+		// TODO: Implement offsetExists() method.
+	}
+
+	/**
+	 * Offset to retrieve
+	 * @link https://php.net/manual/en/arrayaccess.offsetget.php
+	 * @param mixed $offset <p>
+	 * The offset to retrieve.
+	 * </p>
+	 * @return mixed Can return all value types.
+	 * @since 5.0.0
+	 */
+	public function offsetGet($offset) {
+		// TODO: Implement offsetGet() method.
+	}
+
+	/**
+	 * Offset to set
+	 * @link https://php.net/manual/en/arrayaccess.offsetset.php
+	 * @param mixed $offset <p>
+	 * The offset to assign the value to.
+	 * </p>
+	 * @param mixed $value <p>
+	 * The value to set.
+	 * </p>
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetSet($offset, $value) {
+		// TODO: Implement offsetSet() method.
+	}
+
+	/**
+	 * Offset to unset
+	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+	 * @param mixed $offset <p>
+	 * The offset to unset.
+	 * </p>
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetUnset($offset) {
+		// TODO: Implement offsetUnset() method.
+	}
+}

--- a/src/StringMap.php
+++ b/src/StringMap.php
@@ -82,6 +82,7 @@ class StringMap implements ArrayAccess {
 			$propName
 		);
 		array_unshift($nameParts, "data");
+		$nameParts = array_map("strtolower", $nameParts);
 		return implode("-", $nameParts);
 	}
 

--- a/src/StringMap.php
+++ b/src/StringMap.php
@@ -30,13 +30,25 @@ class StringMap implements ArrayAccess {
 		}
 	}
 
+	public function __isset(string $name):bool {
+		return isset($this->properties[$name]);
+	}
+
+	public function __unset(string $name):void {
+		unset($this->properties[$name]);
+		$this->updateOwnerElement();
+	}
+
 	public function __get(string $name):?string {
 		return $this->properties[$name] ?? null;
 	}
 
 	public function __set(string $name, string $value):void {
 		$this->properties[$name] = $value;
+		$this->updateOwnerElement();
+	}
 
+	protected function updateOwnerElement():void {
 		foreach($this->properties as $key => $value) {
 			$this->ownerElement->setAttribute(
 				$this->getAttributeName($key),
@@ -74,60 +86,30 @@ class StringMap implements ArrayAccess {
 	}
 
 	/**
-	 * Whether a offset exists
 	 * @link https://php.net/manual/en/arrayaccess.offsetexists.php
-	 * @param mixed $offset <p>
-	 * An offset to check for.
-	 * </p>
-	 * @return boolean true on success or false on failure.
-	 * </p>
-	 * <p>
-	 * The return value will be casted to boolean if non-boolean was returned.
-	 * @since 5.0.0
 	 */
-	public function offsetExists($offset) {
-		// TODO: Implement offsetExists() method.
+	public function offsetExists($offset):bool {
+		return $this->__isset($this->properties[$offset]);
 	}
 
 	/**
-	 * Offset to retrieve
 	 * @link https://php.net/manual/en/arrayaccess.offsetget.php
-	 * @param mixed $offset <p>
-	 * The offset to retrieve.
-	 * </p>
-	 * @return mixed Can return all value types.
-	 * @since 5.0.0
 	 */
-	public function offsetGet($offset) {
-		// TODO: Implement offsetGet() method.
+	public function offsetGet($offset):?string {
+		return $this->__get($offset);
 	}
 
 	/**
-	 * Offset to set
 	 * @link https://php.net/manual/en/arrayaccess.offsetset.php
-	 * @param mixed $offset <p>
-	 * The offset to assign the value to.
-	 * </p>
-	 * @param mixed $value <p>
-	 * The value to set.
-	 * </p>
-	 * @return void
-	 * @since 5.0.0
 	 */
-	public function offsetSet($offset, $value) {
-		// TODO: Implement offsetSet() method.
+	public function offsetSet($offset, $value):void {
+		$this->__set($offset, $value);
 	}
 
 	/**
-	 * Offset to unset
 	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
-	 * @param mixed $offset <p>
-	 * The offset to unset.
-	 * </p>
-	 * @return void
-	 * @since 5.0.0
 	 */
-	public function offsetUnset($offset) {
-		// TODO: Implement offsetUnset() method.
+	public function offsetUnset($offset):void {
+		$this->__unset($offset);
 	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -265,6 +265,18 @@ class ElementTest extends TestCase {
 		);
 	}
 
+	public function testDatasetSetGet() {
+		$document = new HTMLDocument();
+		$element = $document->createElement("div");
+		$message = "Hello, World!";
+		$element->dataset->message = $message;
+
+		self::assertEquals(
+			$message,
+			$element->dataset->message
+		);
+	}
+
 	public function testDatasetCreateElement() {
 		$document = new HTMLDocument();
 		$element = $document->createElement("div");
@@ -306,10 +318,10 @@ class ElementTest extends TestCase {
 		$document = new HTMLDocument();
 		$element = $document->createElement("div");
 
-		self::assertFalse(isset($this->dataset->name));
+		self::assertFalse(isset($element->dataset->name));
 		$element->dataset->name = "Example";
-		self::assertTrue(isset($this->dataset->name));
+		self::assertTrue(isset($element->dataset->name));
 		unset($element->dataset->name);
-		self::assertFalse(isset($this->dataset->name));
+		self::assertFalse(isset($element->dataset->name));
 	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -300,6 +300,16 @@ class ElementTest extends TestCase {
 		self::assertTrue(isset($element->dataset["name"]));
 		unset($element->dataset["name"]);
 		self::assertFalse(isset($element->dataset["name"]));
+	}
 
+	public function testDatasetIssetUnset() {
+		$document = new HTMLDocument();
+		$element = $document->createElement("div");
+
+		self::assertFalse(isset($this->dataset->name));
+		$element->dataset->name = "Example";
+		self::assertTrue(isset($this->dataset->name));
+		unset($element->dataset->name);
+		self::assertFalse(isset($this->dataset->name));
 	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -265,7 +265,7 @@ class ElementTest extends TestCase {
 		);
 	}
 
-	public function testDataSetCreateElement() {
+	public function testDatasetCreateElement() {
 		$document = new HTMLDocument();
 		$element = $document->createElement("div");
 		$element->dataset->name = "Example";
@@ -278,6 +278,17 @@ class ElementTest extends TestCase {
 		self::assertEquals(
 			$element->dataset->multiWord,
 			$element->getAttribute("data-multi-word")
+		);
+	}
+
+	public function testDatasetArrayAccess() {
+		$document = new HTMLDocument();
+		$element = $document->createElement("div");
+		$element->dataset->name = "Example";
+
+		self::assertEquals(
+			$element->dataset->name,
+			$element->dataset["name"]
 		);
 	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -291,4 +291,15 @@ class ElementTest extends TestCase {
 			$element->dataset["name"]
 		);
 	}
+
+	public function testDatasetArrayAccessIssetUnset() {
+		$document = new HTMLDocument();
+		$element = $document->createElement("div");
+		$element->dataset->name = "Example";
+
+		self::assertTrue(isset($element->dataset["name"]));
+		unset($element->dataset["name"]);
+		self::assertFalse(isset($element->dataset["name"]));
+
+	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -264,4 +264,20 @@ class ElementTest extends TestCase {
 			$p->dataset->socialUsername
 		);
 	}
+
+	public function testDataSetCreateElement() {
+		$document = new HTMLDocument();
+		$element = $document->createElement("div");
+		$element->dataset->name = "Example";
+		$element->dataset->multiWord = "Should be hyphenated";
+
+		self::assertEquals(
+			$element->dataset->name,
+			$element->getAttribute("data-name")
+		);
+		self::assertEquals(
+			$element->dataset->multiWord,
+			$element->getAttribute("data-multi-word")
+		);
+	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -238,16 +238,16 @@ class ElementTest extends TestCase {
 		$this->assertEquals("Goodbye!", $h1->textContent);
 	}
 
-    public function testGetNonExistingIdGivesNull() {
-        $document = new HTMLDocument(Helper::HTML);
-        $body = $document->getElementsByTagName("body")[0] ?? null;
-        self::assertNotNull($body);
-        /** @var Element $body */
-        $idByGetAttribute = $body->getAttribute('id');
-        self::assertNull($idByGetAttribute);
-        $idByPropGetId = $body->prop_get_id();
-        self::assertNull($idByPropGetId);
-        $idByMagicGet = $body->id;
-        self::assertNull($idByMagicGet);
+	public function testGetNonExistingIdGivesNull() {
+		$document = new HTMLDocument(Helper::HTML);
+		$body = $document->getElementsByTagName("body")[0] ?? null;
+		self::assertNotNull($body);
+		/** @var Element $body */
+		$idByGetAttribute = $body->getAttribute('id');
+		self::assertNull($idByGetAttribute);
+		$idByPropGetId = $body->prop_get_id();
+		self::assertNull($idByPropGetId);
+		$idByMagicGet = $body->id;
+		self::assertNull($idByMagicGet);
 	}
 }

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -250,4 +250,18 @@ class ElementTest extends TestCase {
 		$idByMagicGet = $body->id;
 		self::assertNull($idByMagicGet);
 	}
+
+	public function testDataset() {
+		$document = new HTMLDocument(Helper::HTML_MORE);
+		$p = $document->querySelector("p.link-to-twitter");
+
+		self::assertEquals(
+			"twitter",
+			$p->dataset->social
+		);
+		self::assertEquals(
+			"g105b",
+			$p->dataset->socialUsername
+		);
+	}
 }

--- a/test/unit/Helper/Helper.php
+++ b/test/unit/Helper/Helper.php
@@ -39,7 +39,7 @@ HTML;
 	<p>This is so we can test different traversal methods.</p>
 	<p class="plug">This package is a part of the phpgt webengine.</p>
 	<h2 id="who" class="h-who m-before-p m-test">Who made this?</h2>
-	<p class="link-to-twitter">
+	<p class="link-to-twitter" data-social="twitter" data-social-username="g105b">
 		<a href="https://twitter.com/g105b">Greg Bowler</a> started this project
 		to bring modern DOM techniques to the server side.
 	</p>

--- a/test/unit/phpunit.xml
+++ b/test/unit/phpunit.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <phpunit colors="true">
 	<testsuites>
-		<testsuite>
+		<testsuite name="main">
 			<directory suffix="Test.php">.</directory>
 		</testsuite>
 	</testsuites>
 
 	<logging>
 		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true" />
-		<log type="coverage-html" target="./_coverage" charset="UTF-8" highlight="false" lowUpperBound="35" highLowerBound="70" />
+		<log type="coverage-html" target="./_coverage" lowUpperBound="35" highLowerBound="70" />
 	</logging>
 
 	<filter>


### PR DESCRIPTION
The dataset property on the Element interface provides read/write access to all the custom data 
attributes(`data-*`) set on the element. 

This access is available both in HTML and within the DOM.  

It is a StringMap, one entry for each custom data attribute.  

Note that the dataset property itself can be read, but not directly written.  Instead, all writes 
must be to the individual properties within the dataset, which in turn represent the data attributes.   

Note also that an HTML data-attribute and its corresponding DOM dataset.property do not share the 
same name, but they are always similar:

+ The name of a custom data attribute in HTML begins with data-. It must contain only letters, numbers and the following characters: dash (-), dot (.), colon (:), underscore (_) -- but NOT any ASCII capital letters (A to Z).
+ The name of a custom data attribute in PHP is the name of the same HTML attribute but in camelCase and with no dashes, dots, etc.
