### PR TITLE
Fix problem where attribute value contains comma

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "phpgt/cssxpath",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhpGt/CssXPath.git",
-                "reference": "60554671449ab5068e0171116e68d05aec7c0647"
+                "reference": "99184374bd3b9565373c09e3c7be179a5d2298bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/CssXPath/zipball/60554671449ab5068e0171116e68d05aec7c0647",
-                "reference": "60554671449ab5068e0171116e68d05aec7c0647",
+                "url": "https://api.github.com/repos/PhpGt/CssXPath/zipball/99184374bd3b9565373c09e3c7be179a5d2298bb",
+                "reference": "99184374bd3b9565373c09e3c7be179a5d2298bb",
                 "shasum": ""
             },
             "require": {
@@ -38,7 +38,7 @@
                 "MIT"
             ],
             "description": "Convert CSS selectors to XPath queries.",
-            "time": "2019-06-14T15:09:28+00:00"
+            "time": "2019-08-09T15:24:18+00:00"
         }
     ],
     "packages-dev": [
@@ -717,16 +717,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.2.5",
+            "version": "8.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92"
+                "reference": "c319d08ebd31e137034c84ad7339054709491485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1b8534b3730f20f58600124129197bf1183dc92",
-                "reference": "c1b8534b3730f20f58600124129197bf1183dc92",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c319d08ebd31e137034c84ad7339054709491485",
+                "reference": "c319d08ebd31e137034c84ad7339054709491485",
                 "shasum": ""
             },
             "require": {
@@ -742,7 +742,7 @@
                 "phar-io/version": "^2.0.1",
                 "php": "^7.2",
                 "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.5",
+                "phpunit/php-code-coverage": "^7.0.7",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
@@ -770,7 +770,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.2-dev"
+                    "dev-master": "8.3-dev"
                 }
             },
             "autoload": {
@@ -796,7 +796,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-07-15T06:26:24+00:00"
+            "time": "2019-08-03T15:41:47+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1362,8 +1362,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
@@ -1415,16 +1415,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -1436,7 +1436,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1453,12 +1453,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1469,7 +1469,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/test/unit/ElementTest.php
+++ b/test/unit/ElementTest.php
@@ -489,4 +489,14 @@ class ElementTest extends TestCase {
 		self::assertEquals(123.456, $input->valueAsNumber);
 		self::assertIsFloat($input->valueAsNumber);
 	}
+
+	public function testAttributeValueSelection() {
+		$document = new HTMLDocument(Helper::HTML_MORE);
+		$input1 = $document->querySelector("input[name='who']");
+		$input2 = $document->querySelector("input[name=who]");
+		self::assertNotNull($input1);
+		self::assertNotNull($input2);
+		self::assertSame($input1, $input2);
+		self::assertEquals("Scarlett", $input1->value);
+	}
 }


### PR DESCRIPTION
Original issue #207 was created by @dmitriy-krista which uncovered a bug in CssXPath.

I isolated the issue to how CSS queries were split that contained a comma and asked in IRC for some help (Freenode #regex).

User VectorX suggested the regex implementation, and I [implemented it to CssXPath][cssxpath-regex] which I have [validated with a unit test][cssxpath-test]. 

Please provide feedback to this PR if you have time. I'm also happy for VectorX to take credit if they so desire, possibly by adding their details to the [composer.json author's section][cssxpath-authors].

[cssxpath-regex]: https://github.com/PhpGt/CssXPath/commit/99184374bd3b9565373c09e3c7be179a5d2298bb
[cssxpath-test]: https://github.com/PhpGt/CssXPath/commit/cd71106274ba0a0ca0b7576566927951ce82a86b
[cssxpath-authors]: https://github.com/PhpGt/CssXPath/blob/master/composer.json#L28-L35