### PR TITLE
RadioNodeList

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -67,7 +67,7 @@ class Document extends Node implements StreamInterface {
 			$string = $this->domDocument->saveHTML();
 		}
 
-		return $string;
+		return trim($string) . "\n";
 	}
 
 	public function getGtDomNode(DOMNode $nativeNode):Node {

--- a/src/Document.php
+++ b/src/Document.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Dom;
 
+use DOMDocument;
 use DOMException;
 use DOMNode;
 use Gt\Dom\Exception\HTMLDocumentDoesNotSupportCDATASectionException;
@@ -107,7 +108,9 @@ class Document extends Node implements StreamInterface {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Document/doctype */
 	protected function __prop_get_doctype():?DocumentType {
-		$domDoctype = $this->domDocument->getNativeDomNode($this)->doctype;
+		/** @var DOMDocument $nativeDomNode */
+		$nativeDomNode = $this->domDocument->getNativeDomNode($this);
+		$domDoctype = $nativeDomNode->doctype;
 		if(!$domDoctype) {
 			return null;
 		}

--- a/src/DocumentStream.php
+++ b/src/DocumentStream.php
@@ -83,6 +83,8 @@ trait DocumentStream {
 	 * @throws RuntimeException on failure.
 	 */
 	public function seek($offset, $whence = SEEK_SET):void {
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$result = null;
 		$this->fillStream();
 
 		try {

--- a/src/Facade/NodeListFactory.php
+++ b/src/Facade/NodeListFactory.php
@@ -3,6 +3,7 @@ namespace Gt\Dom\Facade;
 
 use Gt\Dom\Node;
 use Gt\Dom\NodeList;
+use Gt\Dom\RadioNodeList;
 
 class NodeListFactory extends NodeList {
 	public static function create(Node...$nodeList):NodeList {
@@ -11,5 +12,9 @@ class NodeListFactory extends NodeList {
 
 	public static function createLive(callable $callback):NodeList {
 		return new NodeList($callback);
+	}
+
+	public static function createRadioNodeList(callable $callback):RadioNodeList {
+		return new RadioNodeList($callback);
 	}
 }

--- a/src/HTMLCollection.php
+++ b/src/HTMLCollection.php
@@ -25,9 +25,8 @@ use Iterator;
  * @see HTMLCollectionFactory
  *
  * @property-read int $length Returns the number of items in the collection.
- * @template T of Element
- * @implements ArrayAccess<int, T>
- * @implements Iterator<int, T>
+ * @implements ArrayAccess<string|int, Element|RadioNodeList|null>
+ * @implements Iterator<int, Element>
  */
 class HTMLCollection implements ArrayAccess, Countable, Iterator {
 	use MagicProp;
@@ -131,14 +130,14 @@ class HTMLCollection implements ArrayAccess, Countable, Iterator {
 	}
 
 	/**
-	 * @param int $offset
+	 * @param string|int $offset
 	 */
-	public function offsetGet($offset):?Element {
+	public function offsetGet($offset):Element|RadioNodeList|null {
 		return $this->item($offset);
 	}
 
 	/**
-	 * @param int $offset
+	 * @param string|int $offset
 	 */
 	public function offsetSet($offset, $value):void {
 		throw new HTMLCollectionImmutableException();

--- a/src/HTMLCollection.php
+++ b/src/HTMLCollection.php
@@ -24,8 +24,9 @@ use Iterator;
  * @see HTMLCollectionFactory
  *
  * @property-read int $length Returns the number of items in the collection.
- * @implements ArrayAccess<int, Element>
- * @implements Iterator<int, Element>
+ * @template T of Element
+ * @implements ArrayAccess<int, T>
+ * @implements Iterator<int, T>
  */
 class HTMLCollection implements ArrayAccess, Countable, Iterator {
 	use MagicProp;

--- a/src/HTMLOptionsCollection.php
+++ b/src/HTMLOptionsCollection.php
@@ -8,9 +8,7 @@ use Gt\Dom\HTMLElement\HTMLOptionElement;
 /**
  * @method HTMLOptionElement current()
  * @method HTMLOptionElement|null offsetGet($offset)
- * @implements Iterator<int, HTMLOptionElement>
- * @implements ArrayAccess<int, HTMLOptionElement>
+ * @extension T of HTMLOptionsElement
  */
 class HTMLOptionsCollection extends HTMLCollection {
-
 }

--- a/src/Node.php
+++ b/src/Node.php
@@ -488,7 +488,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild */
 	protected function __prop_get_firstChild():?Node {
-		$nativeNode = $this->domNode->firstChild;
+		$nativeNode = $this->domNode->firstChild ?? null;
 		if(!$nativeNode) {
 			return null;
 		}
@@ -516,7 +516,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/lastChild */
 	protected function __prop_get_lastChild():?Node {
-		$nativeNode = $this->domNode->lastChild;
+		$nativeNode = $this->domNode->lastChild ?? null;
 		if(!$nativeNode) {
 			return null;
 		}
@@ -526,7 +526,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/nextSibling */
 	protected function __prop_get_nextSibling():?Node {
-		$nativeNode = $this->domNode->nextSibling;
+		$nativeNode = $this->domNode->nextSibling ?? null;
 		if(!$nativeNode) {
 			return null;
 		}
@@ -536,12 +536,12 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName */
 	protected function __prop_get_nodeName():string {
-		return $this->domNode->nodeName;
+		return $this->domNode->nodeName ?? "";
 	}
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType */
 	protected function __prop_get_nodeType():int {
-		return $this->domNode->nodeType;
+		return $this->domNode->nodeType ?? 0;
 	}
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue */
@@ -555,7 +555,7 @@ abstract class Node {
 			return null;
 		}
 
-		return $this->domNode->nodeValue;
+		return $this->domNode->nodeValue ?? null;
 	}
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeValue */
@@ -589,7 +589,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/parentNode */
 	protected function __prop_get_parentNode():?Node {
-		$nativeNode = $this->domNode->parentNode;
+		$nativeNode = $this->domNode->parentNode ?? null;
 		if(!$nativeNode) {
 			return null;
 		}
@@ -599,7 +599,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement */
 	protected function __prop_get_parentElement():?Node {
-		$nativeNode = $this->domNode->parentNode;
+		$nativeNode = $this->domNode->parentNode ?? null;
 		if(!$nativeNode || !$nativeNode instanceof DOMElementFacade) {
 			return null;
 		}
@@ -609,7 +609,7 @@ abstract class Node {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Node/previousSibling */
 	protected function __prop_get_previousSibling():?Node {
-		$nativeNode = $this->domNode->previousSibling;
+		$nativeNode = $this->domNode->previousSibling ?? null;
 		if(!$nativeNode) {
 			return null;
 		}

--- a/src/RadioNodeList.php
+++ b/src/RadioNodeList.php
@@ -1,0 +1,22 @@
+<?php
+namespace Gt\Dom;
+
+use Gt\Dom\HTMLElement\HTMLElement;
+use Gt\Dom\HTMLElement\HTMLInputElement;
+
+/**
+ * @property string $value If the underlying element collection contains radio buttons, the RadioNodeList.value property represents the checked radio button. On retrieving the value property, the value of the currently checked radio button is returned as a string. If the collection does not contain any radio buttons or none of the radio buttons in the collection is in checked state, the empty string is returned. On setting the value property, the first radio button input element whose value property is equal to the new value will be set to checked.
+ */
+class RadioNodeList extends NodeList {
+	/** @link https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList/value */
+	public function __prop_get_value():?string {
+		foreach($this as $node) {
+			/** @var HTMLInputElement $node */
+			if($node->checked) {
+				return $node->value;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/RadioNodeList.php
+++ b/src/RadioNodeList.php
@@ -9,21 +9,29 @@ use Gt\Dom\HTMLElement\HTMLInputElement;
  */
 class RadioNodeList extends NodeList {
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList/value */
-	public function __prop_get_value():?string {
+	public function __prop_get_value():string {
 		foreach($this as $node) {
 			/** @var HTMLInputElement $node */
+			if($node->type !== "radio") {
+				return "";
+			}
+
 			if($node->checked) {
 				return $node->value;
 			}
 		}
 
-		return null;
+		return "";
 	}
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList/value */
 	public function __prop_set_value(string $value):void {
 		foreach($this as $node) {
 			/** @var HTMLInputElement $node */
+			if($node->type !== "radio") {
+				return;
+			}
+
 			if($node->value === $value) {
 				$node->checked = true;
 			}

--- a/src/RadioNodeList.php
+++ b/src/RadioNodeList.php
@@ -19,4 +19,14 @@ class RadioNodeList extends NodeList {
 
 		return null;
 	}
+
+	/** @link https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList/value */
+	public function __prop_set_value(string $value):void {
+		foreach($this as $node) {
+			/** @var HTMLInputElement $node */
+			if($node->value === $value) {
+				$node->checked = true;
+			}
+		}
+	}
 }

--- a/test/phpunit/HTMLCollectionTest.php
+++ b/test/phpunit/HTMLCollectionTest.php
@@ -90,6 +90,52 @@ class HTMLCollectionTest extends TestCase {
 		self::assertEquals("val-2", $radioNodeList->value);
 	}
 
+	public function testNamedItemRadio_noChecked():void {
+		/** @var array<HTMLInputElement> $radioElementList */
+		$radioElementList = [];
+
+		for($i = 0; $i < 10; $i++) {
+			/** @var HTMLInputElement $radio */
+			$radio = NodeTestFactory::createHTMLElement("input");
+			$radio->type = "radio";
+			$radio->name = "example";
+			$radio->value = "val-$i";
+			array_push($radioElementList, $radio);
+		}
+
+		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
+			...$radioElementList
+		));
+
+		$radioNodeList = $sut->namedItem("example");
+		self::assertInstanceOf(RadioNodeList::class, $radioNodeList);
+		self::assertEquals("", $radioNodeList->value);
+	}
+
+	public function testNamedItemRadio_checkbox():void {
+		/** @var array<HTMLInputElement> $radioElementList */
+		$radioElementList = [];
+
+		for($i = 0; $i < 10; $i++) {
+			/** @var HTMLInputElement $radio */
+			$radio = NodeTestFactory::createHTMLElement("input");
+			$radio->type = "checkbox";
+			$radio->name = "example";
+			$radio->value = "val-$i";
+			array_push($radioElementList, $radio);
+		}
+
+		$radioElementList[2]->checked = true;
+
+		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
+			...$radioElementList
+		));
+
+		$radioNodeList = $sut->namedItem("example");
+		self::assertInstanceOf(RadioNodeList::class, $radioNodeList);
+		self::assertEquals("", $radioNodeList->value);
+	}
+
 	public function testNamedItemRadio_setValue():void {
 		/** @var array<HTMLInputElement> $radioElementList */
 		$radioElementList = [];
@@ -117,6 +163,31 @@ class HTMLCollectionTest extends TestCase {
 			else {
 				self::assertFalse($radio->checked);
 			}
+		}
+	}
+
+	public function testNamedItemRadio_setValue_checkbox():void {
+		/** @var array<HTMLInputElement> $radioElementList */
+		$radioElementList = [];
+
+		for($i = 0; $i < 10; $i++) {
+			/** @var HTMLInputElement $radio */
+			$radio = NodeTestFactory::createHTMLElement("input");
+			$radio->type = "checkbox";
+			$radio->name = "example";
+			$radio->value = "val-$i";
+			array_push($radioElementList, $radio);
+		}
+
+		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
+			...$radioElementList
+		));
+
+		$radioNodeList = $sut->namedItem("example");
+		$radioNodeList->value = "val-7";
+
+		foreach($radioElementList as $radio) {
+			self::assertFalse($radio->checked);
 		}
 	}
 

--- a/test/phpunit/HTMLCollectionTest.php
+++ b/test/phpunit/HTMLCollectionTest.php
@@ -90,6 +90,36 @@ class HTMLCollectionTest extends TestCase {
 		self::assertEquals("val-2", $radioNodeList->value);
 	}
 
+	public function testNamedItemRadio_setValue():void {
+		/** @var array<HTMLInputElement> $radioElementList */
+		$radioElementList = [];
+
+		for($i = 0; $i < 10; $i++) {
+			/** @var HTMLInputElement $radio */
+			$radio = NodeTestFactory::createHTMLElement("input");
+			$radio->type = "radio";
+			$radio->name = "example";
+			$radio->value = "val-$i";
+			array_push($radioElementList, $radio);
+		}
+
+		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
+			...$radioElementList
+		));
+
+		$radioNodeList = $sut->namedItem("example");
+		$radioNodeList->value = "val-7";
+
+		foreach($radioElementList as $i => $radio) {
+			if($i === 7) {
+				self::assertTrue($radio->checked);
+			}
+			else {
+				self::assertFalse($radio->checked);
+			}
+		}
+	}
+
 	public function testOffsetExists():void {
 		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
 			NodeTestFactory::createNode("example"),

--- a/test/phpunit/HTMLCollectionTest.php
+++ b/test/phpunit/HTMLCollectionTest.php
@@ -5,6 +5,8 @@ use Gt\Dom\Element;
 use Gt\Dom\Exception\HTMLCollectionImmutableException;
 use Gt\Dom\Facade\HTMLCollectionFactory;
 use Gt\Dom\Facade\NodeListFactory;
+use Gt\Dom\HTMLCollection;
+use Gt\Dom\HTMLOptionsCollection;
 use Gt\Dom\Test\TestFactory\NodeTestFactory;
 use PHPUnit\Framework\TestCase;
 

--- a/test/phpunit/HTMLCollectionTest.php
+++ b/test/phpunit/HTMLCollectionTest.php
@@ -5,8 +5,8 @@ use Gt\Dom\Element;
 use Gt\Dom\Exception\HTMLCollectionImmutableException;
 use Gt\Dom\Facade\HTMLCollectionFactory;
 use Gt\Dom\Facade\NodeListFactory;
-use Gt\Dom\HTMLCollection;
-use Gt\Dom\HTMLOptionsCollection;
+use Gt\Dom\HTMLElement\HTMLInputElement;
+use Gt\Dom\RadioNodeList;
 use Gt\Dom\Test\TestFactory\NodeTestFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -64,6 +64,30 @@ class HTMLCollectionTest extends TestCase {
 		self::assertSame($element2, $sut->namedItem("second"));
 		self::assertSame($element2, $sut->namedItem("xyz"));
 		self::assertNull($sut->namedItem("nope"));
+	}
+
+	public function testNamedItemRadio():void {
+		/** @var array<HTMLInputElement> $radioElementList */
+		$radioElementList = [];
+
+		for($i = 0; $i < 10; $i++) {
+			/** @var HTMLInputElement $radio */
+			$radio = NodeTestFactory::createHTMLElement("input");
+			$radio->type = "radio";
+			$radio->name = "example";
+			$radio->value = "val-$i";
+			array_push($radioElementList, $radio);
+		}
+
+		$radioElementList[2]->checked = true;
+
+		$sut = HTMLCollectionFactory::create(fn() => NodeListFactory::create(
+			...$radioElementList
+		));
+
+		$radioNodeList = $sut->namedItem("example");
+		self::assertInstanceOf(RadioNodeList::class, $radioNodeList);
+		self::assertEquals("val-2", $radioNodeList->value);
 	}
 
 	public function testOffsetExists():void {

--- a/test/phpunit/HTMLElement/HTMLFormElementTest.php
+++ b/test/phpunit/HTMLElement/HTMLFormElementTest.php
@@ -6,6 +6,7 @@ use Gt\Dom\HTMLElement\HTMLFormElement;
 use Gt\Dom\HTMLElement\HTMLInputElement;
 use Gt\Dom\HTMLElement\HTMLTextAreaElement;
 use Gt\Dom\HTMLFormControlsCollection;
+use Gt\Dom\RadioNodeList;
 use Gt\Dom\Test\TestFactory\NodeTestFactory;
 
 class HTMLFormElementTest extends HTMLElementTestCase {


### PR DESCRIPTION
Here is my implementation of the RadioNodeList object.

https://developer.mozilla.org/en-US/docs/Web/API/RadioNodeList

The RadioNodeList interface represents a collection of radio elements in a <form> or a <fieldset> element.

> `RadioNodeList.value`
>    If the underlying element collection contains radio buttons, the value property represents the checked radio button. On retrieving the value property, the value of the currently checked radio button is returned as a string. If the collection does not contain any radio buttons or none of the radio buttons in the collection is in checked state, the empty string is returned. On setting the value property, the first radio button input element whose value property is equal to the new value will be set to checked. 