### PR TITLE
DOMStringMap improvements with PHP 8.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     outputs:
       coverage: ${{ steps.store-coverage.outputs.coverage_text }}
@@ -90,7 +90,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     steps:
       - uses: actions/download-artifact@v3
@@ -112,7 +112,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     steps:
       - uses: actions/download-artifact@v3
@@ -136,7 +136,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
 
     steps:
       - uses: actions/download-artifact@v3

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "phpgt/dom",
-	"description": "The modern DOM API for PHP projects.",
+	"description": "Modern DOM API.",
 	"type": "library",
 
 	"require": {

--- a/src/DOMStringMap.php
+++ b/src/DOMStringMap.php
@@ -52,7 +52,7 @@ class DOMStringMap implements Countable {
 
 	private function correctCamelCase(string $name):string {
 		preg_match_all(
-			'/((?:^|[A-Z])[a-z\-]+)/',
+			'/((?:^|[A-Z])[0-9a-z\-]+)/',
 			$name,
 			$matches
 		);

--- a/src/Document.php
+++ b/src/Document.php
@@ -335,10 +335,10 @@ abstract class Document extends DOMDocument implements Stringable, StreamInterfa
 
 	/**
 	 * @see Node::isEqualNode()
-	 * @param Node|Element $otherNode
-	 * @noinspection PhpParameterNameChangedDuringInheritanceInspection
 	 */
-	public function isEqualNode(Node|Element|DOMNode $otherNode):bool {
+	public function isEqualNode(
+		null|Node|Element|Document|DocumentType|Attr|ProcessingInstruction|DOMNode $otherNode
+	):bool {
 		return $this->documentElement->isEqualNode($otherNode);
 	}
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -5,6 +5,7 @@ use ArrayAccess;
 use Countable;
 use DOMElement;
 use DOMNamedNodeMap;
+use DOMNode;
 use Gt\Dom\Exception\InvalidAdjacentPositionException;
 use Gt\Dom\Exception\XPathQueryException;
 use Gt\PropFunc\MagicProp;
@@ -329,14 +330,11 @@ class Element extends DOMElement implements ArrayAccess, Countable {
 	 * 'beforeend': Just inside the targetElement, after its last child.
 	 * 'afterend': After the targetElement itself.
 	 *
-	 * @param Node|Element $element The element to be inserted into the tree.
-	 * @return ?Element The element that was inserted, or null, if the
-	 * insertion failed.
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentElement
 	 */
 	public function insertAdjacentElement(
 		string $position,
-		Node|Element|DocumentFragment|Text $element
+		DOMElement|DOMNode|Element|Node|DocumentFragment|Text $element
 	):?Element {
 		switch($position) {
 		case "beforebegin":

--- a/src/HTMLElement.php
+++ b/src/HTMLElement.php
@@ -1892,6 +1892,7 @@ trait HTMLElement {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement/disabled
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/disabled
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/disabled
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElemnet/disabled
 	 */
 	protected function __prop_get_disabled():bool {
 		$this->allowTypes(
@@ -1903,6 +1904,7 @@ trait HTMLElement {
 			ElementType::HTMLOptionElement,
 			ElementType::HTMLStyleElement,
 			ElementType::HTMLInputElement,
+			ElementType::HTMLSelectElement,
 		);
 		return $this->hasAttribute("disabled");
 	}
@@ -1915,6 +1917,7 @@ trait HTMLElement {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement/disabled
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/disabled
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElemnet/disabled
+	 * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElemnet/disabled
 	 */
 	protected function __prop_set_disabled(bool $value):void {
 		$this->allowTypes(
@@ -1925,6 +1928,7 @@ trait HTMLElement {
 			ElementType::HTMLOptionElement,
 			ElementType::HTMLStyleElement,
 			ElementType::HTMLInputElement,
+			ElementType::HTMLSelectElement,
 		);
 		if($value) {
 			$this->setAttribute("disabled", "");

--- a/src/RegisteredNodeClass.php
+++ b/src/RegisteredNodeClass.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Dom;
 
+use DOMNameSpaceNode;
 use DOMNode;
 
 /**
@@ -22,13 +23,14 @@ trait RegisteredNodeClass {
 	 * Returns a Boolean which indicates whether or not two nodes are of
 	 * the same type and all their defining data points match.
 	 *
-	 * @param Node|Element|Document|DocumentType|Attr|ProcessingInstruction $otherNode
+	 * @param null|Node|Element|Document|DocumentType|Attr|ProcessingInstruction|DOMNode $otherNode
 	 * The Node to compare equality with.
-	 * @return bool
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Node/isEqualNode
 	 */
 	// phpcs:ignore
-	public function isEqualNode(Node|Element|Document|DocumentType|Attr|ProcessingInstruction|DOMNode $otherNode):bool {
+	public function isEqualNode(
+		null|Node|Element|Document|DocumentType|Attr|ProcessingInstruction|DOMNode $otherNode
+	):bool {
 		if($otherNode instanceof Document) {
 			$otherNode = $otherNode->documentElement;
 		}
@@ -163,13 +165,11 @@ trait RegisteredNodeClass {
 	 * Returns a Boolean value indicating whether or not a node is a
 	 * descendant of the calling node.
 	 *
-	 * @param Node $otherNode
-	 * @return bool
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Node/contains
 	 */
 	public function contains(
 		Node|Element|Text|ProcessingInstruction|DocumentType|DocumentFragment
-		|Document|Comment|CdataSection|Attr $otherNode
+		|Document|Comment|CdataSection|Attr|DOMNode|DOMNameSpaceNode|null $otherNode
 	):bool {
 		$context = $otherNode;
 

--- a/test/phpunit/DOMStringMapTest.php
+++ b/test/phpunit/DOMStringMapTest.php
@@ -19,7 +19,7 @@ class DOMStringMapTest extends TestCase {
 		self::assertSame($keyValuePairs["example"], $sut->example);
 	}
 
-	public function testGetterCamelCaseConversion():void {
+	public function testGetter_fromCamelCase():void {
 		$keyValuePairs = [
 			"this-is-camel-case" => uniqid("example-"),
 		];
@@ -32,6 +32,44 @@ class DOMStringMapTest extends TestCase {
 		$sut = new DOMStringMap($getter, $setter);
 
 		self::assertSame($keyValuePairs["this-is-camel-case"], $sut->thisIsCamelCase);
+	}
+
+	public function testGetter_fromHyphenated():void {
+		$keyValuePairs = [
+			"this-is-camel-case" => uniqid("example-"),
+		];
+		$getter = function() use (&$keyValuePairs) {
+			return $keyValuePairs;
+		};
+		$setter = function(array $kvp) use (&$keyValuePairs) {
+			$keyValuePairs = $kvp;
+		};
+		$sut = new DOMStringMap($getter, $setter);
+
+		self::assertSame($keyValuePairs["this-is-camel-case"], $sut->get("this-is-camel-case"));
+		self::assertSame($keyValuePairs["this-is-camel-case"], $sut->get("thisIsCamelCase"));
+		self::assertArrayNotHasKey("thisIsCamelCase", $keyValuePairs);
+	}
+
+	public function testSetter_fromHyphenated():void {
+		$keyValuePairs = [
+			"this-is-camel-case" => uniqid("example-"),
+		];
+		$getter = function() use (&$keyValuePairs) {
+			return $keyValuePairs;
+		};
+		$setter = function(array $kvp) use (&$keyValuePairs) {
+			$keyValuePairs = $kvp;
+		};
+		$sut = new DOMStringMap($getter, $setter);
+
+		$sut->set("this-is-camel-case", "update1");
+		$sut->set("thisIsCamelCase", "update2");
+		$sut->set("other-key", "other-update");
+
+		self::assertCount(2, $keyValuePairs);
+		self::assertSame("update2", $sut->thisIsCamelCase);
+		self::assertSame("other-update", $sut->otherKey);
 	}
 
 	public function testSetterCamelCaseConversion():void {

--- a/test/phpunit/DOMStringMapTest.php
+++ b/test/phpunit/DOMStringMapTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpUndefinedFieldInspection */
 namespace Gt\Dom\Test;
 
 use Gt\Dom\DOMStringMap;
@@ -46,5 +46,23 @@ class DOMStringMapTest extends TestCase {
 		$sut->thisIsCamelCase = "example123";
 		self::assertSame("example123", $sut->get("thisIsCamelCase"));
 		self::assertSame("example123", $sut->get("this-is-camel-case"));
+	}
+
+	public function testSetter_withNumbers():void {
+		$keyValuePairs = [];
+		$getter = function() use (&$keyValuePairs) {
+			return $keyValuePairs;
+		};
+		$setter = function(array $kvp) use (&$keyValuePairs) {
+			$keyValuePairs = $kvp;
+		};
+		$sut = new DOMStringMap($getter, $setter);
+		$sut->example1 = "one";
+		$sut->example2 = "two";
+		$sut->example3 = "three";
+
+		self::assertSame("one", $sut->example1);
+		self::assertSame("two", $sut->example2);
+		self::assertSame("three", $sut->example3);
 	}
 }


### PR DESCRIPTION
This PR fixes #448 but also introduces introduces PHP 8.3 support, which tightens a lot of type safety.