### PR TITLE
Prevent DocumentFragment from causing internal PHP error by using append()

### DIFF
--- a/src/ParentNode.php
+++ b/src/ParentNode.php
@@ -60,13 +60,18 @@ trait ParentNode {
 	 * 	returns the appended Node object.
 	 * + Element.append() can append several nodes and strings, whereas
 	 * 	Node.appendChild() can only append one node.
-	 * @param Node|Element|Text|Comment|string...$nodes
+	 * @param Node|Element|Text|Comment|DocumentFragment|string...$nodes
 	 */
 	public function append(...$nodes):void {
 // Without this clumsy iteration, PHP 8.1 throws "free(): double free detected in tcache 2"
 		foreach($nodes as $node) {
-			/** @phpstan-ignore-next-line libxml's DOMNode does not define append() */
-			parent::append($node);
+// And without this clumsy if/else, PHP 8.3 throws "double free or corruption (!prev)"
+			if(is_string($node)) {
+				parent::append($node);
+			}
+			else {
+				parent::appendChild($node);
+			}
 		}
 	}
 

--- a/test/phpunit/DocumentFragmentTest.php
+++ b/test/phpunit/DocumentFragmentTest.php
@@ -21,4 +21,18 @@ class DocumentFragmentTest extends TestCase {
 		$sut->appendChild($nodeWithId);
 		self::assertSame($nodeWithId, $sut->getElementById("test"));
 	}
+
+	public function testAppendMultipleNodesThenAddToParentElement():void {
+		$document = new HTMLDocument();
+		$sut = $document->createDocumentFragment();
+		$expectedString = "";
+		for($i = 0; $i < 10; $i++) {
+			$textNode = $document->createTextNode("Node$i");
+			$sut->append($textNode);
+			$expectedString .= "Node$i";
+		}
+
+		$document->documentElement->append($sut);
+		self::assertSame($expectedString, $document->textContent);
+	}
 }


### PR DESCRIPTION
This is some weird libxml behaviour. I'm going to put in an upstream bug fix at some point, but one of the purposes of this library is to patch this kind of weird behaviour. All tests passing now.