### PR TITLE
Fix TypeError when retrieving innerText from elements containing <style>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Composer install
         uses: php-actions/composer@v6
@@ -27,9 +27,9 @@ jobs:
         run: mkdir /tmp/github-actions/ && tar -cvf /tmp/github-actions/build.tar ./
 
       - name: Upload build archive for test runners
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: build-artifact
+          name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
 
   phpunit:
@@ -43,9 +43,9 @@ jobs:
       coverage: ${{ steps.store-coverage.outputs.coverage_text }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: build-artifact
+          name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
 
       - name: Extract build archive
@@ -62,28 +62,31 @@ jobs:
           coverage_clover: _coverage/clover.xml
 
       - name: Store coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: code-coverage
+          name: code-coverage-${{ matrix.php }}-${{ github.run_number }}
           path: _coverage
 
   coverage:
     runs-on: ubuntu-latest
     needs: [ phpunit ]
+    strategy:
+      matrix:
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: code-coverage
+          name: code-coverage-${{ matrix.php }}-${{ github.run_number }}
           path: _coverage
 
       - name: Output coverage
         run: cat "_coverage/coverage.txt"
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
 
   phpstan:
     runs-on: ubuntu-latest
@@ -93,9 +96,9 @@ jobs:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: build-artifact
+          name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
 
       - name: Extract build archive
@@ -116,9 +119,9 @@ jobs:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: build-artifact
+          name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
 
       - name: Extract build archive
@@ -140,9 +143,9 @@ jobs:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: build-artifact
+          name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
 
       - name: Extract build archive
@@ -163,7 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "/repos/${{ github.repository }}/actions/artifacts?name=build-artifact" | jq ".artifacts[] | select(.name == \"build-artifact\") | .id" > artifact-id-list.txt
+          gh api "/repos/${{ github.repository }}/actions/artifacts?name=build-artifact" | jq ".artifacts[] | select(.name | startswith(\"build-artifact\")) | .id" > artifact-id-list.txt
           while read id
           do
             echo -n "Deleting artifact ID $id ... "

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "phpgt/cssxpath",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhpGt/CssXPath.git",
-                "reference": "c0a06671fed8db601bb680dc4d5accf3cd9deb81"
+                "reference": "45f3ac151fc21d459e2515c3aff97cd4bf877bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/CssXPath/zipball/c0a06671fed8db601bb680dc4d5accf3cd9deb81",
-                "reference": "c0a06671fed8db601bb680dc4d5accf3cd9deb81",
+                "url": "https://api.github.com/repos/PhpGt/CssXPath/zipball/45f3ac151fc21d459e2515c3aff97cd4bf877bf8",
+                "reference": "45f3ac151fc21d459e2515c3aff97cd4bf877bf8",
                 "shasum": ""
             },
             "require": {
@@ -50,7 +50,7 @@
             "description": "Convert CSS selectors to XPath queries.",
             "support": {
                 "issues": "https://github.com/PhpGt/CssXPath/issues",
-                "source": "https://github.com/PhpGt/CssXPath/tree/v1.2.0"
+                "source": "https://github.com/PhpGt/CssXPath/tree/v1.3.0"
             },
             "funding": [
                 {
@@ -58,7 +58,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-01-03T18:33:56+00:00"
+            "time": "2024-07-10T13:36:01+00:00"
         },
         {
             "name": "phpgt/propfunc",
@@ -314,16 +314,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -362,7 +362,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -370,7 +370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -696,16 +696,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.14",
+            "version": "1.12.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
+                "reference": "14276fdef70575106a3392a4ed553c06a984df28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/14276fdef70575106a3392a4ed553c06a984df28",
+                "reference": "14276fdef70575106a3392a4ed553c06a984df28",
                 "shasum": ""
             },
             "require": {
@@ -750,7 +750,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-31T07:26:13+00:00"
+            "time": "2025-03-09T09:24:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1075,16 +1075,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.40",
+            "version": "10.5.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c"
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6ddda95af52f69c1e0c7b4f977cccb58048798c",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
+                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
                 "shasum": ""
             },
             "require": {
@@ -1156,7 +1156,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.40"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
             },
             "funding": [
                 {
@@ -1172,7 +1172,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:49:06+00:00"
+            "time": "2025-02-06T16:08:12+00:00"
         },
         {
             "name": "psr/container",
@@ -2195,16 +2195,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.2",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
                 "shasum": ""
             },
             "require": {
@@ -2269,9 +2269,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-12-11T16:04:26+00:00"
+            "time": "2025-03-18T05:04:51+00:00"
         },
         {
             "name": "symfony/config",
@@ -2350,16 +2354,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.16",
+            "version": "v6.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "7a379d8871f6a36f01559c14e11141cc02eb8dc8"
+                "reference": "b343c3b2f1539fe41331657b37d5c96c1d1ea842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7a379d8871f6a36f01559c14e11141cc02eb8dc8",
-                "reference": "7a379d8871f6a36f01559c14e11141cc02eb8dc8",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b343c3b2f1539fe41331657b37d5c96c1d1ea842",
+                "reference": "b343c3b2f1539fe41331657b37d5c96c1d1ea842",
                 "shasum": ""
             },
             "require": {
@@ -2411,7 +2415,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.16"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.19"
             },
             "funding": [
                 {
@@ -2427,7 +2431,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-25T14:52:46+00:00"
+            "time": "2025-02-20T10:02:49+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2806,16 +2810,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.13",
+            "version": "v6.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "0f605f72a363f8743001038a176eeb2a11223b51"
+                "reference": "be6e71b0c257884c1107313de5d247741cfea172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0f605f72a363f8743001038a176eeb2a11223b51",
-                "reference": "0f605f72a363f8743001038a176eeb2a11223b51",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/be6e71b0c257884c1107313de5d247741cfea172",
+                "reference": "be6e71b0c257884c1107313de5d247741cfea172",
                 "shasum": ""
             },
             "require": {
@@ -2863,7 +2867,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.13"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.19"
             },
             "funding": [
                 {
@@ -2879,7 +2883,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:18:03+00:00"
+            "time": "2025-02-13T09:33:32+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/RegisteredNodeClass.php
+++ b/src/RegisteredNodeClass.php
@@ -10,10 +10,10 @@ use DOMNode;
  * functions shared over all Node types.
  *
  * @property-read HTMLDocument|XMLDocument $ownerDocument
- * @property-read null|Node|Element|Text $nextSibling Returns a Node representing the next node in the tree, or null if there isn't such node.
- * @property-read null|Node|Element|Text $firstChild
- * @property-read null|Node|Element|Text $lastChild
- * @property-read null|Node|Element|Text $previousSibling Returns a Node representing the previous node in the tree, or null if there isn't such node.
+ * @property-read null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $nextSibling Returns a Node representing the next node in the tree, or null if there isn't such node.
+ * @property-read null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $firstChild
+ * @property-read null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $lastChild
+ * @property-read null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $previousSibling Returns a Node representing the previous node in the tree, or null if there isn't such node.
  * @property-read bool $isConnected A boolean indicating whether the Node is connected (directly or indirectly) to the Document object.
  *
  * @method Node|Element cloneNode(bool $deep = false)

--- a/src/Traversal.php
+++ b/src/Traversal.php
@@ -272,10 +272,14 @@ trait Traversal {
 					continue;
 				}
 
-				$result = $this->filter->acceptNode($node);
-				if($result === NodeFilter::FILTER_ACCEPT) {
-					return $node;
-				}
+                if (get_class($node) === CdataSection::class) {
+                    $result = NodeFilter::FILTER_REJECT;
+                } else {
+                    $result = $this->filter->acceptNode($node);
+                    if ($result === NodeFilter::FILTER_ACCEPT) {
+                        return $node;
+                    }
+                }
 			}
 			while($result === NodeFilter::FILTER_REJECT
 			&& !is_null($node->firstChild));
@@ -411,7 +415,7 @@ trait Traversal {
 	}
 
 	private function nextSkippingChildren(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node,
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $node,
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $stayWithin
 	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
 		if($node === $stayWithin) {

--- a/src/Traversal.php
+++ b/src/Traversal.php
@@ -17,7 +17,7 @@ trait Traversal {
 	|Document|DocumentType|DocumentFragment $validity;
 
 	protected function __construct(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $root,
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$root,
 		int $whatToShow = NodeFilter::SHOW_ALL,
 		NodeFilter|callable|null $filter = null
 	) {
@@ -77,7 +77,7 @@ trait Traversal {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/root */
 	protected function __prop_get_root(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->pRoot;
 	}
 
@@ -93,7 +93,7 @@ trait Traversal {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/currentNode */
 	protected function __prop_get_currentNode(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->pCurrentNode;
 	}
 
@@ -108,7 +108,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/parentNode
 	 */
 	public function parentNode(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$node = $this->pCurrentNode;
 
 		while($node && $node !== $this->pRoot) {
@@ -136,7 +136,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/firstChild
 	 */
 	public function firstChild(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->traverseChildren("first");
 	}
 
@@ -150,7 +150,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/lastChild
 	 */
 	public function lastChild(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->traverseChildren("last");
 	}
 
@@ -164,7 +164,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/previousSibling
 	 */
 	public function previousSibling(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->traverseSiblings("previous");
 	}
 
@@ -177,7 +177,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/nextSibling
 	 */
 	public function nextSibling(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->traverseSiblings("next");
 	}
 
@@ -192,15 +192,15 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/previousNode
 	 */
 	public function previousNode(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
-		/** @var null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node */
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+		/** @var null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node */
 		$node = $this->pCurrentNode;
 
 		while($node !== $this->pRoot) {
 			$sibling = $node->previousSibling;
 
 			while(!is_null($sibling)) {
-				/** @var null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node */
+				/** @var null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node */
 				$node = $sibling;
 				/** @phpstan-ignore-next-line */
 				$result = $this->filter->acceptNode($node);
@@ -248,7 +248,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/nextNode
 	 */
 	public function nextNode(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		if($node = $this->getNextNode($this->pCurrentNode)) {
 			/** @var Node $node */
 			$this->pCurrentNode = $node;
@@ -259,12 +259,13 @@ trait Traversal {
 	}
 
 	private function getNextNode(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $node
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$result = NodeFilter::FILTER_ACCEPT;
 
 		while(true) {
 			do {
+				/** @var Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $node */
 				if($node->firstChild) {
 					$node = $node->firstChild;
 				}
@@ -302,7 +303,7 @@ trait Traversal {
 	}
 
 	public function current(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $this->pCurrentNode;
 	}
 
@@ -328,7 +329,7 @@ trait Traversal {
 
 	private function traverseChildren(
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$node = $this->matchChild($this->pCurrentNode, $direction);
 		if(!$node) {
 			return null;
@@ -337,9 +338,9 @@ trait Traversal {
 	}
 
 	private function recurseTraverseChildren(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node,
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$overrideNode = null;
 
 		while($node) {
@@ -366,7 +367,7 @@ trait Traversal {
 
 	private function traverseSiblings(
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$node = $this->pCurrentNode;
 
 		if($node === $this->pRoot) {
@@ -390,9 +391,9 @@ trait Traversal {
 	}
 
 	private function matchChild(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node,
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$result = match($direction) {
 			"first" => $node->firstChild,
 			"last", "next", "previous" => $node->lastChild,
@@ -402,9 +403,9 @@ trait Traversal {
 	}
 
 	private function matchSibling(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $node,
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		$result = match($direction) {
 			"next" => $node->nextSibling,
 			"previous" => $node->previousSibling,
@@ -416,8 +417,8 @@ trait Traversal {
 
 	private function nextSkippingChildren(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $node,
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $stayWithin
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$stayWithin
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		if($node === $stayWithin) {
 			return null;
 		}
@@ -487,8 +488,8 @@ trait Traversal {
 	 * correct types that are in use.
 	 */
 	private function hintNodeType(
-		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $input
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$input
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $input;
 	}
 
@@ -499,8 +500,8 @@ trait Traversal {
 	 * correct types that are in use.
 	 */
 	private function hintNullableNodeType(
-		null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment $input
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment {
+		null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$input
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
 		return $input;
 	}
 }

--- a/src/Traversal.php
+++ b/src/Traversal.php
@@ -275,7 +275,8 @@ trait Traversal {
 
 				if (get_class($node) === CdataSection::class) {
 					$result = NodeFilter::FILTER_REJECT;
-				} else {
+				}
+				else {
 					$result = $this->filter->acceptNode($node);
 					if ($result === NodeFilter::FILTER_ACCEPT) {
 						return $node;

--- a/src/Traversal.php
+++ b/src/Traversal.php
@@ -272,14 +272,14 @@ trait Traversal {
 					continue;
 				}
 
-                if (get_class($node) === CdataSection::class) {
-                    $result = NodeFilter::FILTER_REJECT;
-                } else {
-                    $result = $this->filter->acceptNode($node);
-                    if ($result === NodeFilter::FILTER_ACCEPT) {
-                        return $node;
-                    }
-                }
+				if (get_class($node) === CdataSection::class) {
+					$result = NodeFilter::FILTER_REJECT;
+				} else {
+					$result = $this->filter->acceptNode($node);
+					if ($result === NodeFilter::FILTER_ACCEPT) {
+						return $node;
+					}
+				}
 			}
 			while($result === NodeFilter::FILTER_REJECT
 			&& !is_null($node->firstChild));

--- a/src/Traversal.php
+++ b/src/Traversal.php
@@ -77,7 +77,7 @@ trait Traversal {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/root */
 	protected function __prop_get_root(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->pRoot;
 	}
 
@@ -93,7 +93,7 @@ trait Traversal {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/currentNode */
 	protected function __prop_get_currentNode(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->pCurrentNode;
 	}
 
@@ -108,7 +108,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/parentNode
 	 */
 	public function parentNode(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$node = $this->pCurrentNode;
 
 		while($node && $node !== $this->pRoot) {
@@ -136,7 +136,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/firstChild
 	 */
 	public function firstChild(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->traverseChildren("first");
 	}
 
@@ -150,7 +150,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/lastChild
 	 */
 	public function lastChild(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->traverseChildren("last");
 	}
 
@@ -164,7 +164,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/previousSibling
 	 */
 	public function previousSibling(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->traverseSiblings("previous");
 	}
 
@@ -192,7 +192,7 @@ trait Traversal {
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker/previousNode
 	 */
 	public function previousNode(
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		/** @var null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node */
 		$node = $this->pCurrentNode;
 
@@ -303,7 +303,7 @@ trait Traversal {
 	}
 
 	public function current(
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $this->pCurrentNode;
 	}
 
@@ -329,7 +329,7 @@ trait Traversal {
 
 	private function traverseChildren(
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$node = $this->matchChild($this->pCurrentNode, $direction);
 		if(!$node) {
 			return null;
@@ -340,7 +340,7 @@ trait Traversal {
 	private function recurseTraverseChildren(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$overrideNode = null;
 
 		while($node) {
@@ -367,7 +367,7 @@ trait Traversal {
 
 	private function traverseSiblings(
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$node = $this->pCurrentNode;
 
 		if($node === $this->pRoot) {
@@ -393,7 +393,7 @@ trait Traversal {
 	private function matchChild(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$result = match($direction) {
 			"first" => $node->firstChild,
 			"last", "next", "previous" => $node->lastChild,
@@ -405,7 +405,7 @@ trait Traversal {
 	private function matchSibling(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$node,
 		string $direction
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		$result = match($direction) {
 			"next" => $node->nextSibling,
 			"previous" => $node->previousSibling,
@@ -418,7 +418,7 @@ trait Traversal {
 	private function nextSkippingChildren(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection $node,
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$stayWithin
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		if($node === $stayWithin) {
 			return null;
 		}
@@ -489,7 +489,7 @@ trait Traversal {
 	 */
 	private function hintNodeType(
 		Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$input
-	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $input;
 	}
 
@@ -501,7 +501,7 @@ trait Traversal {
 	 */
 	private function hintNullableNodeType(
 		null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection$input
-	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection{
+	):null|Node|Element|Text|Attr|ProcessingInstruction|Comment|Document|DocumentType|DocumentFragment|CdataSection {
 		return $input;
 	}
 }

--- a/test/phpunit/DOMParserTest.php
+++ b/test/phpunit/DOMParserTest.php
@@ -59,4 +59,29 @@ HTML;
 			$document
 		);
 	}
+
+    public function testParseStringWithStyle(): void
+    {
+        /** @noinspection HtmlRequiredLangAttribute */
+        $html = <<<HTML
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test!</title>
+</head>
+<body>
+    <style>
+    </style>
+    <h1>☆ Hello ☆ World ☆</h1>
+</body>
+</html>
+HTML;
+        $sut = new DOMParser();
+        $document = $sut->parseFromString($html, "text/html");
+        self::assertEquals(
+            '☆ Hello ☆ World ☆',
+            trim($document->querySelector('body')->innerText)
+        );
+    }
 }

--- a/test/phpunit/DOMParserTest.php
+++ b/test/phpunit/DOMParserTest.php
@@ -60,8 +60,7 @@ HTML;
 		);
 	}
 
-	public function testParseStringWithStyle(): void
-	{
+	public function testParseStringWithStyle(): void {
 		/** @noinspection HtmlRequiredLangAttribute */
 		$html = <<<HTML
 <!doctype html>

--- a/test/phpunit/DOMParserTest.php
+++ b/test/phpunit/DOMParserTest.php
@@ -60,10 +60,10 @@ HTML;
 		);
 	}
 
-    public function testParseStringWithStyle(): void
-    {
-        /** @noinspection HtmlRequiredLangAttribute */
-        $html = <<<HTML
+	public function testParseStringWithStyle(): void
+	{
+		/** @noinspection HtmlRequiredLangAttribute */
+		$html = <<<HTML
 <!doctype html>
 <html>
 <head>
@@ -77,11 +77,11 @@ HTML;
 </body>
 </html>
 HTML;
-        $sut = new DOMParser();
-        $document = $sut->parseFromString($html, "text/html");
-        self::assertEquals(
-            '☆ Hello ☆ World ☆',
-            trim($document->querySelector('body')->innerText)
-        );
-    }
+		$sut = new DOMParser();
+		$document = $sut->parseFromString($html, "text/html");
+		self::assertEquals(
+			'☆ Hello ☆ World ☆',
+			trim($document->querySelector('body')->innerText)
+		);
+	}
 }


### PR DESCRIPTION
### Description

This PR fixes a TypeError that occurs when retrieving innerText from an element that contains a <style> tag. The issue happens because the <style> tag introduces a CdataSection, which was not properly handled in the traversal process.
Related to the issue described in https://github.com/phpgt/Dom/issues/460.


### Fix:
The fix ensures that CdataSection nodes (introduced by <style> tags) are correctly handled during traversal.
- Updated Traversal::getNextNode()
     * Added a condition to check if the node is an instance of CdataSection.
     * If it is, we apply NodeFilter::FILTER_REJECT to exclude it from traversal.
- Updated Traversal::nextSkippingChildren()
    * Allowed CdataSection as a valid type for the $node parameter.

### Impact:
Prevents crashes when processing innerText of elements containing <style> tags