### PR TITLE
Security: remove possibility of token leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           php_version: ${{ matrix.php }}
 
       - name: Archive build
-        run: mkdir /tmp/github-actions/ && tar -cvf /tmp/github-actions/build.tar ./
+        run: mkdir /tmp/github-actions/ && tar --exclude=".git" -cvf /tmp/github-actions/build.tar ./
 
       - name: Upload build archive for test runners
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "/repos/${{ github.repository }}/actions/artifacts?name=build-artifact" | jq ".artifacts[] | select(.name | startswith(\"build-artifact\")) | .id" > artifact-id-list.txt
+          gh api "/repos/${{ github.repository }}/actions/artifacts" | jq ".artifacts[] | select(.name | startswith(\"build-artifact\")) | .id" > artifact-id-list.txt
           while read id
           do
             echo -n "Deleting artifact ID $id ... "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
   remove_old_artifacts:
     runs-on: ubuntu-latest
 
+    permissions:
+      actions: write
+
     steps:
       - name: Remove old artifacts for prior workflow runs on this repository
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  actions: read
+  id-token: none
+
 jobs:
   composer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The build artifact that is passed between jobs included the .git directory, which contained a config file that stored an access token.

The token inside the file was automatically revoked as soon as the Github Action was completed, but there is a feasibility that under an attack condition, this token could be kept alive. See the documentation at https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication

To resolve any potential token leakage, the .git directory is not included within the build artifact, and on top of this, the token permissions are explicitly set in the workflow file.