### PR TITLE
test: ensure `empty()` behaves as expected with `value` property closes #471

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
+          retention-days: 1
 
   phpunit:
     runs-on: ubuntu-latest
@@ -161,21 +162,3 @@ jobs:
           php_version: ${{ matrix.php }}
           path: src/
           standard: phpcs.xml
-
-  remove_old_artifacts:
-    runs-on: ubuntu-latest
-
-    permissions:
-      actions: write
-
-    steps:
-      - name: Remove old artifacts for prior workflow runs on this repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api "/repos/${{ github.repository }}/actions/artifacts" | jq ".artifacts[] | select(.name | startswith(\"build-artifact\")) | .id" > artifact-id-list.txt
-          while read id
-          do
-            echo -n "Deleting artifact ID $id ... "
-            gh api --method DELETE /repos/${{ github.repository }}/actions/artifacts/$id && echo "Done"
-          done <artifact-id-list.txt

--- a/test/phpunit/ElementTest.php
+++ b/test/phpunit/ElementTest.php
@@ -650,4 +650,23 @@ class ElementTest extends TestCase {
 		self::assertStringContainsString($copyright, $h1->innerHTML);
 		self::assertStringContainsString($trademark, $h1->innerHTML);
 	}
+
+	public function testValue_empty():void {
+		$document = new HTMLDocument("<!doctype html><input name='test' />");
+		$sut = $document->querySelector("input[name='test']");
+		self::assertEmpty($sut->value);
+	}
+
+	public function testValue_notEmptyFromHTML():void {
+		$document = new HTMLDocument("<!doctype html><input name='test' value='abcdef' />");
+		$sut = $document->querySelector("input[name='test']");
+		self::assertNotEmpty($sut->value);
+	}
+
+	public function testValue_notEmptyFromProperty():void {
+		$document = new HTMLDocument();
+		$sut = $document->createElement("input");
+		$sut->value = "abcdef";
+		self::assertNotEmpty($sut->value);
+	}
 }


### PR DESCRIPTION
A project I was working with uses the old DOMDocument model (not GT/Dom) and because the `value` property was loaded via `__get`, it was showing up as `empty()`!

I wanted to test this isn't the case for this repository.

Good news: it works as expected.

@pixeldrift64 FYI