### PR TITLE
Textarea values and ampersands #476

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -147,6 +147,10 @@ class Element extends DOMElement implements ArrayAccess, Countable {
 
 	/** @link https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML */
 	public function __prop_get_innerHTML():string {
+		if($this->elementType === ElementType::HTMLTextAreaElement) {
+			return $this->textContent;
+		}
+
 		$html = "";
 
 		foreach($this->childNodes as $child) {

--- a/src/HTMLElement.php
+++ b/src/HTMLElement.php
@@ -836,7 +836,7 @@ trait HTMLElement {
 			}
 		}
 		elseif($this->elementType === ElementType::HTMLTextAreaElement) {
-			$this->nodeValue = $value;
+			$this->textContent = $value;
 		}
 		else {
 			$this->setAttribute("value", $value);

--- a/test/phpunit/ElementTest.php
+++ b/test/phpunit/ElementTest.php
@@ -669,4 +669,20 @@ class ElementTest extends TestCase {
 		$sut->value = "abcdef";
 		self::assertNotEmpty($sut->value);
 	}
+
+	public function testValue_textAreaAmpersand():void {
+		$document = new HTMLDocument();
+		$sut = $document->createElement("textarea");
+		$string = "This & that";
+		$sut->value = $string;
+		self::assertSame($string, $sut->innerHTML);
+	}
+
+	public function testValue_textAreaAmpersandInnerHTML():void {
+		$document = new HTMLDocument();
+		$sut = $document->createElement("textarea");
+		$string = "This & that";
+		$sut->innerHTML = $string;
+		self::assertSame($string, $sut->value);
+	}
 }


### PR DESCRIPTION
ElementTest has a new test: textValue_textAreaAmpersand, which isolates the bug in issue #476

The bug is caused by the textarea `value` setter using `nodeValue`, as this behaviour is expected with libxml's implementation with the current character set.

The solution requires special handling of strings when manipulating text areas in particular.

This PR closes #476