### PR TITLE
Return empty document fragment from appendChild

### DIFF
--- a/src/ParentNode.php
+++ b/src/ParentNode.php
@@ -101,14 +101,14 @@ trait ParentNode {
 	 * DOM tree, the node will be detached from its current position and
 	 * attached at the new position.
 	 *
-	 * @param Node|Element|Text|Comment $aChild The node to append to the
+	 * @param Node|Element|Text|Comment|DocumentFragment $aChild The node to append to the
 	 * given parent node (commonly an element).
-	 * @return Node|Element The returned value is the appended
+	 * @return Node|Element|DocumentFragment The returned value is the appended
 	 * child (aChild), except when aChild is a DocumentFragment, in which
 	 * case the empty DocumentFragment is returned.
 	 * @link https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
 	 */
-	public function appendChild(Node|Element|Text|Comment|DOMNode $aChild):Node|Element|Text|Comment {
+	public function appendChild(Node|Element|Text|Comment|DOMNode $aChild):Node|Element|Text|Comment|DocumentFragment {
 		if($this instanceof Document) {
 			if($aChild instanceof Text) {
 				throw new TextNodeCanNotBeRootNodeException("Cannot insert a Text as a child of a Document");
@@ -117,6 +117,10 @@ trait ParentNode {
 			if($this->childElementCount > 0) {
 				throw new DocumentHasMoreThanOneElementChildException("Cannot have more than one Element child of a Document");
 			}
+		}
+
+		if($aChild instanceof DocumentFragment && !$aChild->hasChildNodes()) {
+			return $aChild;
 		}
 
 		try {

--- a/test/phpunit/NodeTest.php
+++ b/test/phpunit/NodeTest.php
@@ -44,6 +44,17 @@ class NodeTest extends TestCase {
 		self::assertCount(1, $sut->childNodes);
 	}
 
+	public function testAppendChildEmptyDocumentFragment():void {
+		$document = new HTMLDocument();
+		$sut = $document->createElement("example");
+		$fragment = $document->createDocumentFragment();
+
+		$appended = $sut->appendChild($fragment);
+
+		self::assertSame($fragment, $appended);
+		self::assertCount(0, $sut->childNodes);
+	}
+
 	public function testChildNodesManyLive():void {
 		$document = new HTMLDocument();
 		$sut = $document->createElement("example");


### PR DESCRIPTION
## Summary

- return an empty `DocumentFragment` from `appendChild()` instead of propagating the native `false` result
- add a regression test that verifies object identity and confirms the parent remains unchanged

## Why

PHP's native `DOMNode::appendChild()` returns `false` for an empty document fragment. The wrapper's strict return type turns that value into a `TypeError`, while the DOM API is expected to return the appended fragment.

## Testing

- `composer test` (960 tests, 3829 assertions; PHPStan, PHPCS, and PHPMD passed)
- `composer validate --strict --no-check-publish`
- focused `NodeTest` and `DocumentFragmentTest` suite (65 tests, 95 assertions)
- manual empty and non-empty fragment checks

Closes #458
